### PR TITLE
🧪 add unit tests for Solid TextInput component

### DIFF
--- a/packages/solid/src/components/text-input/TextInput.test.tsx
+++ b/packages/solid/src/components/text-input/TextInput.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { TextInput } from "./TextInput";
+
+describe("TextInput", () => {
+	it("renders basic input with label and placeholder", () => {
+		render(() => (
+			<TextInput
+				label="Username"
+				placeholder="Enter your username"
+				testId="username"
+			/>
+		));
+
+		expect(screen.getByText("Username")).toBeInTheDocument();
+		const input = screen.getByPlaceholderText("Enter your username");
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute("data-testid", "username--input");
+	});
+
+	it("renders hint and error messages", () => {
+		const { rerender } = render(() => (
+			<TextInput
+				label="Email"
+				hint="We will never share your email."
+				testId="email"
+			/>
+		));
+
+		expect(screen.getByText("We will never share your email.")).toBeInTheDocument();
+
+		rerender(() => (
+			<TextInput
+				label="Email"
+				error="Invalid email address"
+				testId="email"
+			/>
+		));
+
+		expect(screen.getByText("Invalid email address")).toBeInTheDocument();
+		expect(screen.getByTestId("email--input")).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("renders start and end sections", () => {
+		render(() => (
+			<TextInput
+				label="Search"
+				startSection={<span data-testid="search-icon">🔍</span>}
+				endSection={<button type="button" data-testid="clear-button">X</button>}
+				testId="search"
+			/>
+		));
+
+		expect(screen.getByTestId("search-icon")).toBeInTheDocument();
+		expect(screen.getByTestId("clear-button")).toBeInTheDocument();
+
+		const input = screen.getByTestId("search--input");
+		expect(input).toHaveAttribute("data-with-start-section", "true");
+		expect(input).toHaveAttribute("data-with-end-section", "true");
+	});
+
+	it("calls onValueChange and onInput when typing", () => {
+		const onValueChange = vi.fn();
+		const onInput = vi.fn();
+
+		render(() => (
+			<TextInput
+				label="Name"
+				onValueChange={onValueChange}
+				onInput={onInput}
+				testId="name"
+			/>
+		));
+
+		const input = screen.getByTestId("name--input") as HTMLInputElement;
+		fireEvent.input(input, { target: { value: "John" } });
+
+		expect(onValueChange).toHaveBeenCalledWith("John");
+		expect(onInput).toHaveBeenCalled();
+	});
+
+	it("handles disabled and readOnly states", () => {
+		const { rerender } = render(() => (
+			<TextInput label="Disabled" disabled testId="disabled" />
+		));
+
+		expect(screen.getByTestId("disabled--input")).toBeDisabled();
+
+		rerender(() => (
+			<TextInput label="Read Only" readOnly testId="readonly" />
+		));
+
+		expect(screen.getByTestId("readonly--input")).toHaveAttribute("readonly");
+	});
+
+	it("applies required attribute", () => {
+		render(() => <TextInput label="Required" required testId="required" />);
+		expect(screen.getByTestId("required--input")).toBeRequired();
+	});
+});


### PR DESCRIPTION
Implemented missing unit tests for the Solid `TextInput` component. The new test suite in `packages/solid/src/components/text-input/TextInput.test.tsx` ensures that all major features and states are correctly handled:

1.  **Rendering:** Confirmed that labels and placeholders are correctly rendered.
2.  **Field Features:** Verified that hints and error messages are displayed.
3.  **Sections:** Asserted that `startSection` and `endSection` render with proper data attributes (`data-with-start-section`, `data-with-end-section`).
4.  **Interactions:** Tested `onValueChange` and `onInput` callbacks when user input is received.
5.  **States:** Covered `disabled`, `readOnly`, and `required` attributes on the underlying input element.
6.  **Accessibility:** Ensured `aria-invalid` is correctly set when an error is present.

This improvement increases the test coverage for the Solid component library and provides a safety net for future changes to the `TextInput` component.

---
*PR created automatically by Jules for task [843875712944472259](https://jules.google.com/task/843875712944472259) started by @dryu*