### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,10 @@ When given a Linear issue ID (e.g. `TMPRL-123`):
 - Do not use `npm install`, `yarn`, or `pnpm`
 - Do not run `eslint` or `prettier`; use Biome
 - Do not run `lint` or `typecheck` without first running `build` (or expect a build to run as part of the pipeline)
+
+## Cursor Cloud specific instructions
+
+- **Bun is installed at `~/.bun/bin/bun`**. The update script handles installation. If running bun in a fresh tmux session, ensure `~/.bun/bin` is on `PATH` (e.g. `source ~/.bashrc` or `export PATH="$HOME/.bun/bin:$PATH"`).
+- **Lefthook postinstall may fail** due to Cursor's `core.hooksPath` git config. Use `bun install --ignore-scripts` if `bun install` fails, then run `bunx lefthook install --force` separately. This is a non-blocking issue — lefthook hooks are optional for agent workflows.
+- **No external services required**. This is a pure frontend component library; all tests run in-memory (happy-dom/jsdom).
+- **Lint warning is expected**: Biome reports 1 CSS specificity warning in the core package — this is pre-existing and not a failure.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious gotchas discovered during environment setup:

- Bun path configuration for tmux sessions
- Lefthook postinstall failure workaround (Cursor's `core.hooksPath` conflict)
- Confirmation that no external services are needed
- Note about the pre-existing Biome CSS specificity warning

### Environment Verification

All checks pass on a clean setup:

| Check | Status |
|-------|--------|
| `bun run build` | All 3 packages built |
| `bun run lint` | Passed (1 pre-existing CSS warning) |
| `bun run typecheck` | Passed |
| `bun run test` | All tests passed across core, react, solid |
| `bun run react` (Storybook) | Running on port 6006 |

### Demo

<a href="https://cursor.com/agents/bc-b0aa5c15-8ddd-462d-a0d6-ee7a43fd31ab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_component_demo.mp4"><img src="https://cursor.com/artifacts/c/art-f98e42df-5aaa-450c-a84e-1e98ad9f50b1" alt="storybook_component_demo.mp4" /></a>
React Storybook running with Button, Alert, and Card components.

![Storybook Button component docs page](https://cursor.com/artifacts/c/art-81f98592-0b4c-4d60-a3b2-f627b53fd9a8)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0aa5c15-8ddd-462d-a0d6-ee7a43fd31ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0aa5c15-8ddd-462d-a0d6-ee7a43fd31ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

