### PR TITLE
feat(TPX-448): expose RadioGroup and Select Ark class slots

### DIFF
--- a/packages/core/src/components/radio-group/index.ts
+++ b/packages/core/src/components/radio-group/index.ts
@@ -1,1 +1,1 @@
-export type { RadioGroupItem, RadioGroupProps } from "./radio";
+export type { RadioGroupClasses, RadioGroupItem, RadioGroupProps } from "./radio";

--- a/packages/core/src/components/radio-group/radio.ts
+++ b/packages/core/src/components/radio-group/radio.ts
@@ -6,8 +6,25 @@ export type RadioGroupItem = {
 	disabled?: boolean;
 };
 
-export interface RadioGroupProps<T> extends FieldProps<T> {
+/** Class slots for Field layout plus Ark `RadioGroup` parts. */
+export type RadioGroupClasses = Pick<NonNullable<FieldProps<unknown>["classes"]>, "root" | "label" | "hint" | "error"> & {
+	/** `RadioGroup.Root` */
+	group?: string;
+	/** `RadioGroup.Indicator` */
+	indicator?: string;
+	/** `RadioGroup.Item` */
+	item?: string;
+	/** `RadioGroup.ItemControl` */
+	itemControl?: string;
+	/** `RadioGroup.ItemText` */
+	itemText?: string;
+	/** `RadioGroup.ItemHiddenInput` */
+	itemInput?: string;
+};
+
+export interface RadioGroupProps<T> extends Omit<FieldProps<T>, "classes"> {
 	items: RadioGroupItem[];
+	classes?: RadioGroupClasses;
 	defaultValue?: string;
 	value?: string;
 	onValueChange?: (value: string | null) => void;

--- a/packages/core/src/components/radio-group/radio.ts
+++ b/packages/core/src/components/radio-group/radio.ts
@@ -7,7 +7,10 @@ export type RadioGroupItem = {
 };
 
 /** Class slots for Field layout plus Ark `RadioGroup` parts. */
-export type RadioGroupClasses = Pick<NonNullable<FieldProps<unknown>["classes"]>, "root" | "label" | "hint" | "error"> & {
+export type RadioGroupClasses = Pick<
+	NonNullable<FieldProps<unknown>["classes"]>,
+	"root" | "label" | "hint" | "error"
+> & {
 	/** `RadioGroup.Root` */
 	group?: string;
 	/** `RadioGroup.Indicator` */

--- a/packages/core/src/components/select/select.ts
+++ b/packages/core/src/components/select/select.ts
@@ -25,10 +25,12 @@ export interface SelectProps<T = unknown> extends FieldProps<T> {
 		scrollArea?: string;
 		content?: string;
 		control?: string;
+		trigger?: string;
 		itemGroup?: string;
 		itemIndicator?: string;
 		item?: string;
 		indicator?: string;
 		valueText?: string;
+		itemText?: string;
 	};
 }

--- a/packages/react/src/components/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/components/radio-group/RadioGroup.test.tsx
@@ -29,4 +29,27 @@ describe("RadioGroup", () => {
 			expect(screen.getByLabelText(item.label)).toBeInTheDocument();
 		});
 	});
+
+	it("applies classes to Ark radio group parts", () => {
+		render(
+			<RadioGroup
+				testId="rg"
+				label="Pick one"
+				items={items.slice(0, 2)}
+				classes={{
+					group: "slot-group",
+					indicator: "slot-indicator",
+					item: "slot-item",
+					itemControl: "slot-control",
+					itemText: "slot-text",
+					itemInput: "slot-input",
+				}}
+			/>,
+		);
+		expect(screen.getByTestId("rg--root")).toHaveClass("slot-group");
+		expect(screen.getByTestId("rg--item-option1")).toHaveClass("slot-item");
+		expect(screen.getByTestId("rg--item-control-option1")).toHaveClass("slot-control");
+		expect(screen.getByTestId("rg--item-text-option1")).toHaveClass("slot-text");
+		expect(screen.getByTestId("rg--item-input-option1")).toHaveClass("slot-input");
+	});
 });

--- a/packages/react/src/components/radio-group/RadioGroup.tsx
+++ b/packages/react/src/components/radio-group/RadioGroup.tsx
@@ -5,7 +5,7 @@ import { Field } from "../field";
 
 export interface RadioGroupProps extends CoreRadioGroupProps<React.ReactNode> {}
 
-export type { RadioGroupItem } from "@temporal-ui/core/radio-group";
+export type { RadioGroupClasses, RadioGroupItem } from "@temporal-ui/core/radio-group";
 
 export function RadioGroup(props: RadioGroupProps) {
 	const {
@@ -14,6 +14,7 @@ export function RadioGroup(props: RadioGroupProps) {
 		error,
 		disabled,
 		items,
+		classes,
 		defaultValue,
 		value,
 		required,
@@ -31,9 +32,11 @@ export function RadioGroup(props: RadioGroupProps) {
 			disabled={disabled}
 			required={required}
 			readOnly={readOnly}
+			classes={classes}
 			testId={testId ? `${testId}-field` : undefined}
 		>
 			<ArkRadioGroup.Root
+				className={classes?.group}
 				defaultValue={defaultValue}
 				disabled={disabled}
 				value={value}
@@ -43,20 +46,30 @@ export function RadioGroup(props: RadioGroupProps) {
 				aria-required={required}
 				data-testid={testId ? `${testId}--root` : undefined}
 			>
-				<ArkRadioGroup.Indicator />
+				<ArkRadioGroup.Indicator className={classes?.indicator} />
 				{items.map((item) => (
 					<ArkRadioGroup.Item
 						key={item.value}
+						className={classes?.item}
 						value={item.value}
 						disabled={item.disabled}
 						invalid={!!error}
 						data-testid={testId ? `${testId}--item-${item.value}` : undefined}
 					>
-						<ArkRadioGroup.ItemControl data-testid={testId ? `${testId}--item-control-${item.value}` : undefined} />
-						<ArkRadioGroup.ItemText data-testid={testId ? `${testId}--item-text-${item.value}` : undefined}>
+						<ArkRadioGroup.ItemControl
+							className={classes?.itemControl}
+							data-testid={testId ? `${testId}--item-control-${item.value}` : undefined}
+						/>
+						<ArkRadioGroup.ItemText
+							className={classes?.itemText}
+							data-testid={testId ? `${testId}--item-text-${item.value}` : undefined}
+						>
 							{item.label}
 						</ArkRadioGroup.ItemText>
-						<ArkRadioGroup.ItemHiddenInput data-testid={testId ? `${testId}--item-input-${item.value}` : undefined} />
+						<ArkRadioGroup.ItemHiddenInput
+							className={classes?.itemInput}
+							data-testid={testId ? `${testId}--item-input-${item.value}` : undefined}
+						/>
 					</ArkRadioGroup.Item>
 				))}
 			</ArkRadioGroup.Root>

--- a/packages/react/src/components/radio-group/index.ts
+++ b/packages/react/src/components/radio-group/index.ts
@@ -1,1 +1,1 @@
-export { RadioGroup, type RadioGroupItem, type RadioGroupProps } from "./RadioGroup";
+export { RadioGroup, type RadioGroupClasses, type RadioGroupItem, type RadioGroupProps } from "./RadioGroup";

--- a/packages/react/src/components/select/Select.test.tsx
+++ b/packages/react/src/components/select/Select.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createListCollection, Select, type SelectItem } from ".";
+
+const collection = createListCollection<SelectItem<unknown>>({
+	items: [
+		{ value: "a", label: "Alpha" },
+		{ value: "b", label: "Beta" },
+	],
+});
+
+describe("Select", () => {
+	it("merges classes.control with className on the control element", () => {
+		render(
+			<Select
+				testId="sel"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				className="from-prop"
+				classes={{ control: "from-classes" }}
+			/>,
+		);
+		const control = screen.getByTestId("sel--control");
+		expect(control).toHaveClass("from-prop");
+		expect(control).toHaveClass("from-classes");
+	});
+
+	it("applies trigger and valueText class slots", () => {
+		render(
+			<Select
+				testId="sel2"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				classes={{ trigger: "slot-trigger", valueText: "slot-value" }}
+			/>,
+		);
+		expect(screen.getByTestId("sel2--trigger")).toHaveClass("slot-trigger");
+		expect(screen.getByTestId("sel2--value-text")).toHaveClass("slot-value");
+	});
+});

--- a/packages/react/src/components/select/Select.tsx
+++ b/packages/react/src/components/select/Select.tsx
@@ -1,6 +1,7 @@
 import { Select as ArkSelect, useSelect, type CollectionItem } from "@ark-ui/react/select";
 import { Portal } from "@ark-ui/react/portal";
 import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import { cx } from "@temporal-ui/core/utils/cx";
 import { Field } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
 import { testId } from "@temporal-ui/core/utils/string";
@@ -50,10 +51,18 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 			testId={tid("-field")}
 		>
 			<ArkSelect.RootProvider value={select} className={classes?.selectRoot} data-testid={tid("--root")}>
-				<ArkSelect.Control aria-invalid={!!error} className={className} data-testid={tid("--control")}>
-					<ArkSelect.Trigger data-testid={tid("--trigger")}>
+				<ArkSelect.Control
+					aria-invalid={!!error}
+					className={cx(classes?.control, className)}
+					data-testid={tid("--control")}
+				>
+					<ArkSelect.Trigger className={classes?.trigger} data-testid={tid("--trigger")}>
 						{select.selectedItems[0]?.icon || icon}
-						<ArkSelect.ValueText placeholder={placeholder} data-testid={tid("--value-text")} />
+						<ArkSelect.ValueText
+							className={classes?.valueText}
+							placeholder={placeholder}
+							data-testid={tid("--value-text")}
+						/>
 						{(!deselectable || !select.hasSelectedItems) && <ChevronsUpDown />}
 					</ArkSelect.Trigger>
 					{deselectable && select.hasSelectedItems && (

--- a/packages/solid/src/components/radio-group/RadioGroup.test.tsx
+++ b/packages/solid/src/components/radio-group/RadioGroup.test.tsx
@@ -29,4 +29,27 @@ describe("RadioGroup", () => {
 			expect(screen.getByLabelText(item.label)).toBeInTheDocument();
 		});
 	});
+
+	it("applies classes to Ark radio group parts", () => {
+		render(() => (
+			<RadioGroup
+				testId="rg"
+				label="Pick one"
+				items={items.slice(0, 2)}
+				classes={{
+					group: "slot-group",
+					indicator: "slot-indicator",
+					item: "slot-item",
+					itemControl: "slot-control",
+					itemText: "slot-text",
+					itemInput: "slot-input",
+				}}
+			/>
+		));
+		expect(screen.getByTestId("rg--group")).toHaveClass("slot-group");
+		expect(screen.getByTestId("rg--item-option1")).toHaveClass("slot-item");
+		expect(screen.getByTestId("rg--item-control-option1")).toHaveClass("slot-control");
+		expect(screen.getByTestId("rg--item-text-option1")).toHaveClass("slot-text");
+		expect(screen.getByTestId("rg--item-input-option1")).toHaveClass("slot-input");
+	});
 });

--- a/packages/solid/src/components/radio-group/RadioGroup.tsx
+++ b/packages/solid/src/components/radio-group/RadioGroup.tsx
@@ -6,7 +6,7 @@ import { Field } from "../field";
 
 export interface RadioGroupProps extends CoreRadioGroupProps<JSX.Element> {}
 
-export type { RadioGroupItem } from "@temporal-ui/core/radio-group";
+export type { RadioGroupClasses, RadioGroupItem } from "@temporal-ui/core/radio-group";
 
 export function RadioGroup(_props: RadioGroupProps) {
 	const [fieldProps, rootProps] = splitProps(_props, [
@@ -20,34 +20,41 @@ export function RadioGroup(_props: RadioGroupProps) {
 		"testId",
 	]);
 
+	const c = fieldProps.classes;
+
 	return (
 		<Field {...fieldProps} testId={fieldProps.testId ? `${fieldProps.testId}-field` : undefined}>
 			<ArkRadioGroup.Root
 				{...rootProps}
+				class={c?.group}
 				disabled={fieldProps.disabled}
 				readOnly={fieldProps.readOnly}
 				aria-required={fieldProps.required}
 				onValueChange={(details) => rootProps.onValueChange?.(details.value)}
 				data-testid={fieldProps.testId ? `${fieldProps.testId}--group` : undefined}
 			>
-				<ArkRadioGroup.Indicator />
+				<ArkRadioGroup.Indicator class={c?.indicator} />
 				<Index each={rootProps.items}>
 					{(item) => (
 						<ArkRadioGroup.Item
+							class={c?.item}
 							value={item().value}
 							disabled={item().disabled}
 							invalid={!!fieldProps.error}
 							data-testid={fieldProps.testId ? `${fieldProps.testId}--item-${item().value}` : undefined}
 						>
 							<ArkRadioGroup.ItemControl
+								class={c?.itemControl}
 								data-testid={fieldProps.testId ? `${fieldProps.testId}--item-control-${item().value}` : undefined}
 							/>
 							<ArkRadioGroup.ItemText
+								class={c?.itemText}
 								data-testid={fieldProps.testId ? `${fieldProps.testId}--item-text-${item().value}` : undefined}
 							>
 								{item().label}
 							</ArkRadioGroup.ItemText>
 							<ArkRadioGroup.ItemHiddenInput
+								class={c?.itemInput}
 								data-testid={fieldProps.testId ? `${fieldProps.testId}--item-input-${item().value}` : undefined}
 							/>
 						</ArkRadioGroup.Item>

--- a/packages/solid/src/components/radio-group/index.ts
+++ b/packages/solid/src/components/radio-group/index.ts
@@ -1,1 +1,1 @@
-export { RadioGroup, type RadioGroupItem, type RadioGroupProps } from "./RadioGroup";
+export { RadioGroup, type RadioGroupClasses, type RadioGroupItem, type RadioGroupProps } from "./RadioGroup";

--- a/packages/solid/src/components/select/Select.test.tsx
+++ b/packages/solid/src/components/select/Select.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import { createListCollection, Select, type SelectItem } from ".";
+
+const collection = createListCollection<SelectItem<unknown>>({
+	items: [
+		{ value: "a", label: "Alpha" },
+		{ value: "b", label: "Beta" },
+	],
+});
+
+describe("Select", () => {
+	it("merges classes.control with class prop on the control element", () => {
+		render(() => (
+			<Select
+				testId="sel"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				class="from-prop"
+				classes={{ control: "from-classes" }}
+			/>
+		));
+		const control = screen.getByTestId("sel--control");
+		expect(control).toHaveClass("from-prop");
+		expect(control).toHaveClass("from-classes");
+	});
+
+	it("applies trigger and valueText class slots", () => {
+		render(() => (
+			<Select
+				testId="sel2"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				classes={{ trigger: "slot-trigger", valueText: "slot-value" }}
+			/>
+		));
+		expect(screen.getByTestId("sel2--trigger")).toHaveClass("slot-trigger");
+		expect(screen.getByTestId("sel2--value-text")).toHaveClass("slot-value");
+	});
+});

--- a/packages/solid/src/components/select/Select.tsx
+++ b/packages/solid/src/components/select/Select.tsx
@@ -1,5 +1,6 @@
 import { Select as ArkSelect, useSelect } from "@ark-ui/solid/select";
 import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import { cx } from "@temporal-ui/core/utils/cx";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-solid";
 import { mergeProps, Show, splitProps, type JSX } from "solid-js";
@@ -34,10 +35,18 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 	return (
 		<Field {...fieldProps} testId={tid("-field")}>
 			<ArkSelect.RootProvider value={select} class={fieldProps.classes?.selectRoot} data-testid={tid("--root")}>
-				<ArkSelect.Control aria-invalid={!!fieldProps.error} class={controlProps.class} data-testid={tid("--control")}>
-					<ArkSelect.Trigger data-testid={tid("--trigger")}>
+				<ArkSelect.Control
+					aria-invalid={!!fieldProps.error}
+					class={cx(fieldProps.classes?.control, controlProps.class)}
+					data-testid={tid("--control")}
+				>
+					<ArkSelect.Trigger class={fieldProps.classes?.trigger} data-testid={tid("--trigger")}>
 						{select().selectedItems[0]?.icon || controlProps.icon}
-						<ArkSelect.ValueText placeholder={controlProps.placeholder} data-testid={tid("--value-text")} />
+						<ArkSelect.ValueText
+							class={fieldProps.classes?.valueText}
+							placeholder={controlProps.placeholder}
+							data-testid={tid("--value-text")}
+						/>
 						<Show when={!controlProps.deselectable || !select().hasSelectedItems}>
 							<ChevronsUpDown />
 						</Show>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses TPX-448: expose named `classes` slots for Ark UI parts on RadioGroup and Select.

### RadioGroup

- Introduces `RadioGroupClasses` in core and narrows `RadioGroupProps.classes` to Field slots plus Ark parts: `group`, `indicator`, `item`, `itemControl`, `itemText`, `itemInput`.
- React `RadioGroup` now forwards `classes` to `Field` and applies the Ark slots (Solid already forwarded `classes` to `Field`; Ark parts are now wired).

### Select

- `classes.control` is merged with the existing root `className` (React) or `class` (Solid) on `Select.Control`.
- `classes.trigger` and `classes.valueText` are declared on the core type and applied to `Select.Trigger` and `Select.ValueText`.

### Tests

- React and Solid tests cover RadioGroup class slots and Select control merge plus trigger/valueText.

## Verification

- `bun run build && bun run lint && bun run typecheck`
- `cd packages/react && bun run test src/components/radio-group/RadioGroup.test.tsx src/components/select/Select.test.tsx`
- `cd packages/solid && bun run test src/components/radio-group/RadioGroup.test.tsx src/components/select/Select.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-448](https://linear.app/temporal1/issue/TPX-448/expose-extra-class-attributes-for-various-components-of-ark-ui)

<div><a href="https://cursor.com/agents/bc-6e9cca81-362b-467d-b13d-d2fa6dc8e1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e9cca81-362b-467d-b13d-d2fa6dc8e1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

