### PR TITLE
chore: bump package versions to 0.8.2 for core, react, and solid packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"


### PR DESCRIPTION
Updated the version of @temporal-ui/core, @temporal-ui/react, and @temporal-ui/solid to 0.8.2 in their respective package.json files to reflect the latest changes.