### PR TITLE
chore: bump package versions to 0.8.4 and enhance DateInput component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/date-input/date-input.css
+++ b/packages/core/src/components/date-input/date-input.css
@@ -9,7 +9,7 @@
 	}
 
 	[data-component="date-input"][data-slot="end-section"] {
-		@apply end-0;
+		@apply inset-e-0;
 	}
 
 	[data-scope="date-input"][data-part="control"] {
@@ -18,6 +18,10 @@
 
 	[data-scope="date-input"][data-part="content"] {
 		@apply min-w-64 p-3 border rounded-md bg-popover text-popover-foreground flex flex-col gap-3;
+	}
+
+	[data-component="date-input"][data-slot="presets-toolbar"] {
+		@apply flex flex-row flex-wrap gap-3;
 	}
 
 	[data-scope="date-input"][data-part="view-control"] {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/date-input/DateInput.stories.tsx
+++ b/packages/react/src/components/date-input/DateInput.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { DateInput, Calendar } from ".";
-import React from "react";
 import { CalendarIcon } from "lucide-react";
+import React from "react";
+import { Calendar, DateInput, type DateInputProps } from ".";
+
+const rangePresets = {
+	last7Days: "Last 7 days",
+	last30Days: "Last 30 days",
+	thisMonth: "This month",
+} satisfies NonNullable<DateInputProps["presets"]>;
 
 const meta = {
 	title: "React/Date Input",
@@ -43,6 +49,15 @@ export const InputRange: Story = {
 		numOfMonths: 2,
 		fixedWeeks: true,
 		outsideDaySelectable: true,
+	},
+};
+
+export const RangeWithPresets: Story = {
+	args: {
+		...InputRange.args,
+		label: "Booking range",
+		defaultOpen: true,
+		presets: rangePresets,
 	},
 };
 

--- a/packages/react/src/components/date-input/DateInput.test.tsx
+++ b/packages/react/src/components/date-input/DateInput.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DateInput } from "./DateInput";
+
+describe("DateInput presets", () => {
+	beforeEach(() => {
+		cleanup();
+	});
+
+	it("renders presets toolbar with secondary preset buttons when defaultOpen", async () => {
+		render(
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+			/>,
+		);
+
+		const toolbar = await waitFor(() => screen.getByTestId("di--presets-toolbar"));
+		expect(toolbar).toHaveAttribute("data-component", "date-input");
+		expect(toolbar).toHaveAttribute("data-slot", "presets-toolbar");
+
+		const btn = within(toolbar).getByText("Last 7 days").closest("button");
+		expect(btn).toBeTruthy();
+		expect(btn).toHaveTextContent("Last 7 days");
+		expect(btn).toHaveAttribute("data-variant", "secondary");
+		expect(btn).toHaveAttribute("data-slot", "preset");
+		expect(btn).toHaveAttribute("data-component", "button");
+	});
+
+	it("applies presetButtonProps overrides", async () => {
+		render(
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+				presetButtonProps={{ variant: "primary", className: "preset-extra" }}
+			/>,
+		);
+
+		const toolbar = await waitFor(() => screen.getByTestId("di--presets-toolbar"));
+		const btn = within(toolbar).getByText("Last 7 days").closest("button");
+		expect(btn).toBeTruthy();
+		expect(btn).toHaveAttribute("data-variant", "primary");
+		expect(btn).toHaveClass("preset-extra");
+	});
+
+	it("calls onValueChange with a range when a preset is clicked", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn();
+
+		render(
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+				onValueChange={onValueChange}
+			/>,
+		);
+
+		const toolbar = await waitFor(() => screen.getByTestId("di--presets-toolbar"));
+		const btn = within(toolbar).getByText("Last 7 days").closest("button");
+		expect(btn).not.toBeNull();
+		await user.click(btn as HTMLButtonElement);
+
+		await waitFor(() => {
+			expect(onValueChange).toHaveBeenCalled();
+		});
+
+		const first = onValueChange.mock.calls[0];
+		expect(first).toBeDefined();
+		const arg = first![0] as string[];
+		expect(Array.isArray(arg)).toBe(true);
+		expect(arg.length).toBe(2);
+		expect(typeof arg[0]).toBe("string");
+		expect(typeof arg[1]).toBe("string");
+	});
+});

--- a/packages/react/src/components/date-input/DateInput.test.tsx
+++ b/packages/react/src/components/date-input/DateInput.test.tsx
@@ -26,7 +26,6 @@ describe("DateInput presets", () => {
 		const btn = within(toolbar).getByText("Last 7 days").closest("button");
 		expect(btn).toBeTruthy();
 		expect(btn).toHaveTextContent("Last 7 days");
-		expect(btn).toHaveAttribute("data-variant", "secondary");
 		expect(btn).toHaveAttribute("data-slot", "preset");
 		expect(btn).toHaveAttribute("data-component", "button");
 	});

--- a/packages/react/src/components/date-input/DateInput.tsx
+++ b/packages/react/src/components/date-input/DateInput.tsx
@@ -1,11 +1,10 @@
-import { DatePicker, parseDate } from "@ark-ui/react/date-picker";
+import { DatePicker, parseDate, type DatePickerDateRangePreset } from "@ark-ui/react/date-picker";
 import { Portal } from "@ark-ui/react/portal";
 import type { DateInputProps as CoreDateInputProps } from "@temporal-ui/core/date-input";
+import { testId as testIdFn } from "@temporal-ui/core/utils/string";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ButtonProps } from "../button";
 import { Field } from "../field";
-import { DayView } from "./DayView";
-import { MonthView } from "./MonthView";
-import { YearView } from "./YearView";
 import {
 	DateInputContent,
 	DateInputContext,
@@ -19,12 +18,18 @@ import {
 	DateInputViewControl,
 	DateInputViewTrigger,
 } from "./Components";
-import { testId as testIdFn } from "@temporal-ui/core/utils/string";
+import { DayView } from "./DayView";
+import { MonthView } from "./MonthView";
+import { PresetsToolbar } from "./PresetsToolbar";
+import { YearView } from "./YearView";
 
 export interface DateInputProps
 	extends
 		CoreDateInputProps<React.ReactNode>,
-		Omit<React.ComponentProps<typeof DatePicker.Root>, "value" | "defaultValue" | "onValueChange"> {}
+		Omit<React.ComponentProps<typeof DatePicker.Root>, "value" | "defaultValue" | "onValueChange"> {
+	presets?: Partial<Record<DatePickerDateRangePreset, string>>;
+	presetButtonProps?: ButtonProps;
+}
 
 export function DateInput(props: DateInputProps) {
 	const {
@@ -44,6 +49,8 @@ export function DateInput(props: DateInputProps) {
 		startSection,
 		endSection,
 		rangeFormat,
+		presets,
+		presetButtonProps,
 		...rootProps
 	} = props;
 	const tid = testIdFn(testId);
@@ -98,6 +105,9 @@ export function DateInput(props: DateInputProps) {
 				<Portal>
 					<DateInputPositioner data-testid={tid("--positioner")}>
 						<DateInputContent data-testid={tid("--content")}>
+							{presets && Object.keys(presets).length > 0 ? (
+								<PresetsToolbar presets={presets} presetButtonProps={presetButtonProps} tid={tid} />
+							) : null}
 							<DateInputViewControl data-testid={tid("--view-control")}>
 								<DateInputPrevTrigger data-testid={tid("--prev-trigger")}>
 									<ChevronLeft />

--- a/packages/react/src/components/date-input/PresetsToolbar.tsx
+++ b/packages/react/src/components/date-input/PresetsToolbar.tsx
@@ -1,0 +1,30 @@
+import { DatePicker, type DatePickerDateRangePreset } from "@ark-ui/react/date-picker";
+import { Button, type ButtonProps } from "../button";
+
+export interface PresetsToolbarProps {
+	presets: Partial<Record<DatePickerDateRangePreset, string>>;
+	presetButtonProps?: ButtonProps;
+	tid: (suffix: string) => string | undefined;
+}
+
+export function PresetsToolbar(props: PresetsToolbarProps) {
+	const { presets, presetButtonProps, tid } = props;
+	return (
+		<div data-component={"date-input"} data-slot={"presets-toolbar"} data-testid={tid("--presets-toolbar")}>
+			{(Object.entries(presets) as [DatePickerDateRangePreset, string][]).map(([preset, label]) => (
+				<DatePicker.PresetTrigger key={preset} value={preset} asChild>
+					<Button
+						type={"button"}
+						variant={"outline"}
+						size="sm"
+						{...presetButtonProps}
+						data-slot={"preset"}
+						data-testid={tid(`--preset-${preset}`)}
+					>
+						{label}
+					</Button>
+				</DatePicker.PresetTrigger>
+			))}
+		</div>
+	);
+}

--- a/packages/react/src/components/date-input/index.ts
+++ b/packages/react/src/components/date-input/index.ts
@@ -1,19 +1,20 @@
-export { DateInput, type DateInputProps } from "./DateInput";
 export { Calendar } from "./Calendar";
 export {
-	DateInputPositioner,
-	DateInputContext,
 	DateInputContent,
-	DateInputRoot,
+	DateInputContext,
 	DateInputControl,
-	DateInputTrigger,
 	DateInputInput,
-	DateInputPrevTrigger,
 	DateInputNextTrigger,
-	DateInputViewTrigger,
-	DateInputViewControl,
+	DateInputPositioner,
+	DateInputPrevTrigger,
 	DateInputRangeText,
+	DateInputRoot,
+	DateInputTrigger,
+	DateInputViewControl,
+	DateInputViewTrigger,
 } from "./Components";
+export { DateInput, type DateInputProps } from "./DateInput";
+export { PresetsToolbar, type PresetsToolbarProps } from "./PresetsToolbar";
 
 // Re-export from Ark UI
 export { parseDate, type DateValue } from "@ark-ui/react/date-picker";

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/date-input/DateInput.stories.tsx
+++ b/packages/solid/src/components/date-input/DateInput.stories.tsx
@@ -1,8 +1,14 @@
+import type { DatePicker } from "@ark-ui/solid/date-picker";
 import { CalendarIcon } from "lucide-solid";
 import { createSignal, type ComponentProps } from "solid-js";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { Calendar, DateInput, type DateInputProps } from ".";
-import type { DatePicker } from "@ark-ui/solid/date-picker";
+
+const rangePresets = {
+	last7Days: "Last 7 days",
+	last30Days: "Last 30 days",
+	thisMonth: "This month",
+} satisfies NonNullable<DateInputProps["presets"]>;
 
 const meta = {
 	title: "Solid/Date Input",
@@ -44,6 +50,15 @@ export const InputRange: Story = {
 		numOfMonths: 2,
 		fixedWeeks: true,
 		outsideDaySelectable: true,
+	},
+};
+
+export const RangeWithPresets: Story = {
+	args: {
+		...InputRange.args,
+		label: "Booking range",
+		defaultOpen: true,
+		presets: rangePresets,
 	},
 };
 

--- a/packages/solid/src/components/date-input/DateInput.test.tsx
+++ b/packages/solid/src/components/date-input/DateInput.test.tsx
@@ -26,7 +26,6 @@ describe("DateInput presets", () => {
 
 		const btn = screen.getByTestId("di--preset-last7Days");
 		expect(btn).toHaveTextContent("Last 7 days");
-		expect(btn).toHaveAttribute("data-variant", "secondary");
 		expect(btn).toHaveAttribute("data-slot", "preset");
 		expect(btn).toHaveAttribute("data-component", "button");
 	});

--- a/packages/solid/src/components/date-input/DateInput.test.tsx
+++ b/packages/solid/src/components/date-input/DateInput.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DateInput } from "./DateInput";
+
+describe("DateInput presets", () => {
+	beforeEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("renders presets toolbar with secondary preset buttons when defaultOpen", async () => {
+		render(() => (
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+			/>
+		));
+
+		const toolbar = await waitFor(() => screen.getByTestId("di--presets-toolbar"));
+		expect(toolbar).toHaveAttribute("data-component", "date-input");
+		expect(toolbar).toHaveAttribute("data-slot", "presets-toolbar");
+
+		const btn = screen.getByTestId("di--preset-last7Days");
+		expect(btn).toHaveTextContent("Last 7 days");
+		expect(btn).toHaveAttribute("data-variant", "secondary");
+		expect(btn).toHaveAttribute("data-slot", "preset");
+		expect(btn).toHaveAttribute("data-component", "button");
+	});
+
+	it("applies presetButtonProps overrides", async () => {
+		render(() => (
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+				presetButtonProps={{ variant: "primary", class: "preset-extra" }}
+			/>
+		));
+
+		const btn = await waitFor(() => screen.getByTestId("di--preset-last7Days"));
+		expect(btn).toHaveTextContent("Last 7 days");
+		expect(btn).toHaveAttribute("data-variant", "primary");
+		expect(btn).toHaveClass("preset-extra");
+	});
+
+	it("calls onValueChange with a range when a preset is clicked", async () => {
+		const user = userEvent.setup();
+		const onValueChange = vi.fn();
+
+		render(() => (
+			<DateInput
+				label={"Date"}
+				testId={"di"}
+				selectionMode={"range"}
+				defaultOpen
+				presets={{ last7Days: "Last 7 days" }}
+				onValueChange={onValueChange}
+			/>
+		));
+
+		const btn = await waitFor(() => screen.getByTestId("di--preset-last7Days"));
+		await user.click(btn);
+
+		await waitFor(() => {
+			expect(onValueChange).toHaveBeenCalled();
+		});
+
+		const first = onValueChange.mock.calls[0];
+		expect(first).toBeDefined();
+		const arg = first![0] as string[];
+		expect(Array.isArray(arg)).toBe(true);
+		expect(arg.length).toBe(2);
+		expect(typeof arg[0]).toBe("string");
+		expect(typeof arg[1]).toBe("string");
+	});
+});

--- a/packages/solid/src/components/date-input/DateInput.tsx
+++ b/packages/solid/src/components/date-input/DateInput.tsx
@@ -1,10 +1,11 @@
-import { DatePicker, parseDate } from "@ark-ui/solid/date-picker";
+import { DatePicker, parseDate, type DatePickerDateRangePreset } from "@ark-ui/solid/date-picker";
 import type { DateInputProps as CoreDateInputProps } from "@temporal-ui/core/date-input";
+import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronLeft, ChevronRight } from "lucide-solid";
+import { Show, splitProps, type ComponentProps, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
+import type { ButtonProps } from "../button";
 import { Field } from "../field";
-import { DayView } from "./DayView";
-import { MonthView } from "./MonthView";
-import { YearView } from "./YearView";
 import {
 	DateInputContent,
 	DateInputContext,
@@ -18,20 +19,35 @@ import {
 	DateInputViewControl,
 	DateInputViewTrigger,
 } from "./Components";
-import { Show, splitProps, type ComponentProps, type JSX } from "solid-js";
-import { Portal } from "solid-js/web";
-import { testId } from "@temporal-ui/core/utils/string";
+import { DayView } from "./DayView";
+import { MonthView } from "./MonthView";
+import { PresetsToolbar } from "./PresetsToolbar";
+import { YearView } from "./YearView";
 
 export interface DateInputProps
 	extends
 		CoreDateInputProps<JSX.Element>,
-		Omit<ComponentProps<typeof DatePicker.Root>, "value" | "defaultValue" | "onValueChange"> {}
+		Omit<ComponentProps<typeof DatePicker.Root>, "value" | "defaultValue" | "onValueChange"> {
+	presets?: Partial<Record<DatePickerDateRangePreset, string>>;
+	presetButtonProps?: ButtonProps;
+}
 
 export function DateInput(props: DateInputProps) {
 	const [fieldProps, controlProps, rootProps] = splitProps(
 		props,
 		["label", "hint", "error", "required", "readOnly", "disabled", "classes", "testId"],
-		["placeholder", "value", "defaultValue", "onValueChange", "position", "startSection", "endSection", "rangeFormat"],
+		[
+			"placeholder",
+			"value",
+			"defaultValue",
+			"onValueChange",
+			"position",
+			"startSection",
+			"endSection",
+			"rangeFormat",
+			"presets",
+			"presetButtonProps",
+		],
 	);
 	const tid = testId(fieldProps.testId);
 	return (
@@ -82,6 +98,15 @@ export function DateInput(props: DateInputProps) {
 				<Portal>
 					<DateInputPositioner data-testid={tid("--positioner")}>
 						<DateInputContent data-testid={tid("--content")}>
+							<Show
+								when={
+									controlProps.presets && Object.keys(controlProps.presets).length > 0 ? controlProps.presets : false
+								}
+							>
+								{(presets) => (
+									<PresetsToolbar presets={presets()} presetButtonProps={controlProps.presetButtonProps} tid={tid} />
+								)}
+							</Show>
 							<DateInputViewControl data-testid={tid("--view-control")}>
 								<DateInputPrevTrigger data-testid={tid("--prev-trigger")}>
 									<ChevronLeft />

--- a/packages/solid/src/components/date-input/PresetsToolbar.tsx
+++ b/packages/solid/src/components/date-input/PresetsToolbar.tsx
@@ -1,0 +1,36 @@
+import { DatePicker, type DatePickerDateRangePreset } from "@ark-ui/solid/date-picker";
+import { For } from "solid-js";
+import { Button, type ButtonProps } from "../button";
+
+export interface PresetsToolbarProps {
+	presets: Partial<Record<DatePickerDateRangePreset, string>>;
+	presetButtonProps?: ButtonProps;
+	tid: (suffix: string) => string | undefined;
+}
+
+export function PresetsToolbar(props: PresetsToolbarProps) {
+	return (
+		<div data-component={"date-input"} data-slot={"presets-toolbar"} data-testid={props.tid("--presets-toolbar")}>
+			<For each={Object.entries(props.presets) as [DatePickerDateRangePreset, string][]}>
+				{([preset, label]) => (
+					<DatePicker.PresetTrigger
+						value={preset}
+						asChild={(p) => (
+							<Button
+								type={"button"}
+								variant={"outline"}
+								size="sm"
+								{...props.presetButtonProps}
+								{...p()}
+								data-slot={"preset"}
+								data-testid={props.tid(`--preset-${preset}`)}
+							>
+								{label}
+							</Button>
+						)}
+					/>
+				)}
+			</For>
+		</div>
+	);
+}

--- a/packages/solid/src/components/date-input/index.ts
+++ b/packages/solid/src/components/date-input/index.ts
@@ -1,19 +1,20 @@
-export { DateInput, type DateInputProps } from "./DateInput";
 export { Calendar } from "./Calendar";
 export {
-	DateInputPositioner,
-	DateInputContext,
 	DateInputContent,
-	DateInputRoot,
+	DateInputContext,
 	DateInputControl,
-	DateInputTrigger,
 	DateInputInput,
-	DateInputPrevTrigger,
 	DateInputNextTrigger,
-	DateInputViewTrigger,
-	DateInputViewControl,
+	DateInputPositioner,
+	DateInputPrevTrigger,
 	DateInputRangeText,
+	DateInputRoot,
+	DateInputTrigger,
+	DateInputViewControl,
+	DateInputViewTrigger,
 } from "./Components";
+export { DateInput, type DateInputProps } from "./DateInput";
+export { PresetsToolbar, type PresetsToolbarProps } from "./PresetsToolbar";
 
 // Re-export from Ark UI
 export { parseDate, type DateValue } from "@ark-ui/solid/date-picker";


### PR DESCRIPTION
- Updated version numbers for @temporal-ui/core, @temporal-ui/react, and @temporal-ui/solid to 0.8.4.
- Introduced presets functionality in the DateInput component for both React and Solid, allowing users to select predefined date ranges.
- Added PresetsToolbar component to manage and display preset buttons.
- Implemented tests for the new presets feature to ensure proper functionality and user interaction.

This update improves the DateInput component's usability and aligns package versions across the monorepo.