### PR TITLE
fix(date-input): section icon contrast on hover in light theme (TPX-462)

### DIFF
--- a/packages/core/src/components/date-input/date-input.css
+++ b/packages/core/src/components/date-input/date-input.css
@@ -5,7 +5,7 @@
 
 	[data-component="date-input"][data-slot="start-section"],
 	[data-component="date-input"][data-slot="end-section"] {
-		@apply absolute text-muted-foreground pointer-events-none flex justify-center items-center h-9 w-9;
+		@apply absolute text-muted-foreground pointer-events-none flex justify-center items-center h-9 w-9 group-hover:text-foreground dark:group-hover:text-muted-foreground;
 	}
 
 	[data-component="date-input"][data-slot="end-section"] {
@@ -13,7 +13,7 @@
 	}
 
 	[data-scope="date-input"][data-part="control"] {
-		@apply w-fit relative;
+		@apply group w-fit relative;
 	}
 
 	[data-scope="date-input"][data-part="content"] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **TPX-462**: calendar (or other) icons in `startSection` / `endSection` were hard to see when hovering the DateInput trigger in the **light** theme, because they kept `text-muted-foreground` while the trigger used `hover:bg-accent`, and those colors sit too close together in `:root`.

## Changes

- Add `group` to `[data-part="control"]` so section wrappers can react to hover anywhere on the control (including the trigger).
- On section slots: `group-hover:text-foreground` for light mode contrast; `dark:group-hover:text-muted-foreground` so dark theme stays as before.

## Testing

- `bun run lint` (pass)
- `packages/react`: `vitest run src/components/date-input/DateInput.test.tsx` (pass)
- `packages/solid`: same (pass)

Note: full monorepo `typecheck` currently reports many pre-existing errors in React test matchers in this environment; not introduced by this CSS-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-462](https://linear.app/temporal1/issue/TPX-462/dateinput-section-icons-on-hover-in-light-theme-disappear)

<div><a href="https://cursor.com/agents/bc-8458efe3-9c1e-4afc-ab84-b3bfcf65302c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8458efe3-9c1e-4afc-ab84-b3bfcf65302c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

