### PR TITLE
feat(menu): nested submenus (TPX-470)

### DIFF
--- a/packages/core/src/components/menu/menu.css
+++ b/packages/core/src/components/menu/menu.css
@@ -35,6 +35,22 @@
 			}
 		}
 
+		[data-part="trigger-item"] {
+			@apply relative flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none cursor-default w-full truncate justify-between;
+			& svg {
+				@apply size-4 text-muted-foreground shrink-0;
+			}
+			&[data-disabled] {
+				@apply opacity-50 pointer-events-none;
+			}
+			&:not([data-disabled]) {
+				@apply focus-visible:bg-accent focus-visible:text-accent-foreground;
+			}
+			&[data-highlighted] {
+				@apply bg-accent text-accent-foreground;
+			}
+		}
+
 		[data-part="item-radio-indicator"] {
 			@apply size-2 rounded-full bg-foreground;
 		}

--- a/packages/core/src/components/menu/menu.ts
+++ b/packages/core/src/components/menu/menu.ts
@@ -22,3 +22,13 @@ export interface MenuRadioItemGroupProps extends MenuItemProps {
 	label?: string;
 	onValueChange?: (value: string) => void;
 }
+
+/** Nested submenu root (`Menu.Root` inside parent menu content). */
+export interface MenuSubProps<T = unknown> extends BaseComponent<T> {
+	position?: Position;
+	onSelect?: (value: string) => void;
+}
+
+export interface MenuSubTriggerProps extends MenuItemProps {}
+
+export interface MenuSubContentProps extends MenuItemProps {}

--- a/packages/react/src/components/menu/Menu.integration.test.tsx
+++ b/packages/react/src/components/menu/Menu.integration.test.tsx
@@ -1,5 +1,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ChevronRight } from "lucide-react";
+import { vi } from "vitest";
 import { Menu } from "./Menu";
 import { MenuCheckboxItem } from "./MenuCheckboxItem";
 import { MenuItem } from "./MenuItem";
@@ -7,6 +9,9 @@ import { MenuItemGroup } from "./MenuItemGroup";
 import { MenuItemSeparator } from "./MenuItemSeparator";
 import { MenuRadioItem } from "./MenuRadioItem";
 import { MenuRadioItemGroup } from "./MenuRadioItemGroup";
+import { MenuSub } from "./MenuSub";
+import { MenuSubContent } from "./MenuSubContent";
+import { MenuSubTrigger } from "./MenuSubTrigger";
 
 describe("Menu Integration Tests", () => {
 	beforeEach(() => {
@@ -99,5 +104,45 @@ describe("Menu Integration Tests", () => {
 
 		await user.click(radioItem);
 		expect(onRadioChange).toHaveBeenCalledWith("option2");
+	});
+
+	it("opens nested submenu and selects a submenu item", async () => {
+		const user = userEvent.setup();
+		const onRootSelect = vi.fn();
+		const onSubSelect = vi.fn();
+
+		render(
+			<Menu trigger={<button type="button">Nested Menu</button>} onSelect={onRootSelect}>
+				<MenuItem value="top">Top action</MenuItem>
+				<MenuSub onSelect={onSubSelect} testId="sub-menu">
+					<MenuSubTrigger>
+						More
+						<ChevronRight aria-hidden />
+					</MenuSubTrigger>
+					<MenuSubContent>
+						<MenuItem value="nested-a">Nested A</MenuItem>
+						<MenuItem value="nested-b">Nested B</MenuItem>
+					</MenuSubContent>
+				</MenuSub>
+			</Menu>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Nested Menu" }));
+
+		await waitFor(() => {
+			expect(screen.getByRole("menu")).toBeVisible();
+		});
+
+		const triggerItem = screen.getByRole("menuitem", { name: /More/i });
+		await user.click(triggerItem);
+
+		await waitFor(() => {
+			expect(screen.getByRole("menuitem", { name: "Nested A" })).toBeVisible();
+		});
+
+		await user.click(screen.getByRole("menuitem", { name: "Nested A" }));
+
+		expect(onSubSelect).toHaveBeenCalledWith("nested-a");
+		expect(onRootSelect).not.toHaveBeenCalled();
 	});
 });

--- a/packages/react/src/components/menu/Menu.stories.tsx
+++ b/packages/react/src/components/menu/Menu.stories.tsx
@@ -10,8 +10,11 @@ import { MenuItem } from "./MenuItem";
 import { MenuItemGroup } from "./MenuItemGroup";
 import { MenuItemSeparator } from "./MenuItemSeparator";
 import { MenuRadioItem } from "./MenuRadioItem";
-import { CreditCard, LogOut, Settings, UserIcon, UserPlus, UsersIcon } from "lucide-react";
 import { MenuRadioItemGroup } from "./MenuRadioItemGroup";
+import { CreditCard, LogOut, Settings, UserIcon, UserPlus, UsersIcon, ChevronRight } from "lucide-react";
+import { MenuSub } from "./MenuSub";
+import { MenuSubContent } from "./MenuSubContent";
+import { MenuSubTrigger } from "./MenuSubTrigger";
 
 const meta = {
 	title: "React/Menu",
@@ -427,6 +430,40 @@ export const MixedItemTypes: Story = {
 	args: {
 		trigger: <SampleTrigger />,
 		children: <SampleMixedMenuItems />,
+	},
+};
+
+export const NestedSubmenus: Story = {
+	args: {
+		trigger: <SampleTrigger />,
+		onSelect: fn(),
+		children: (
+			<>
+				<MenuItem value="profile">
+					<UserIcon />
+					My Profile
+				</MenuItem>
+				<MenuSub>
+					<MenuSubTrigger>
+						Invite member
+						<ChevronRight aria-hidden />
+					</MenuSubTrigger>
+					<MenuSubContent>
+						<MenuItem value="invite-email">By email</MenuItem>
+						<MenuItem value="invite-link">Share link</MenuItem>
+					</MenuSubContent>
+				</MenuSub>
+				<MenuItem value="settings">
+					<Settings />
+					Settings
+				</MenuItem>
+				<MenuItemSeparator />
+				<MenuItem value="logout">
+					<LogOut />
+					Log out
+				</MenuItem>
+			</>
+		),
 	},
 };
 

--- a/packages/react/src/components/menu/MenuSub.tsx
+++ b/packages/react/src/components/menu/MenuSub.tsx
@@ -1,0 +1,35 @@
+import type { MenuSubProps as CoreMenuSubProps } from "@temporal-ui/core/menu";
+import { Menu as ArkMenu } from "@ark-ui/react/menu";
+import type React from "react";
+import { testId as testIdFn } from "@temporal-ui/core/utils/string";
+
+const defaultSubPosition = {
+	placement: "right-start" as const,
+	gutter: -2,
+};
+
+export interface MenuSubProps
+	extends CoreMenuSubProps<React.ReactNode>,
+		Omit<React.ComponentProps<typeof ArkMenu.Root>, "positioning" | "children" | "onSelect"> {
+	children: React.ReactNode;
+}
+
+export function MenuSub(props: MenuSubProps) {
+	const { children, className, position, testId, onSelect, ...rootProps } = props;
+	const tid = testIdFn(testId);
+
+	return (
+		<ArkMenu.Root
+			{...rootProps}
+			className={className}
+			onSelect={(details) => onSelect?.(details.value)}
+			positioning={{
+				...defaultSubPosition,
+				...position,
+			}}
+			data-testid={tid("--sub-root")}
+		>
+			{children}
+		</ArkMenu.Root>
+	);
+}

--- a/packages/react/src/components/menu/MenuSub.tsx
+++ b/packages/react/src/components/menu/MenuSub.tsx
@@ -2,6 +2,7 @@ import type { MenuSubProps as CoreMenuSubProps } from "@temporal-ui/core/menu";
 import { Menu as ArkMenu } from "@ark-ui/react/menu";
 import type React from "react";
 import { testId as testIdFn } from "@temporal-ui/core/utils/string";
+import { Box } from "../box";
 
 const defaultSubPosition = {
 	placement: "right-start" as const,
@@ -9,7 +10,8 @@ const defaultSubPosition = {
 };
 
 export interface MenuSubProps
-	extends CoreMenuSubProps<React.ReactNode>,
+	extends
+		CoreMenuSubProps<React.ReactNode>,
 		Omit<React.ComponentProps<typeof ArkMenu.Root>, "positioning" | "children" | "onSelect"> {
 	children: React.ReactNode;
 }
@@ -21,7 +23,6 @@ export function MenuSub(props: MenuSubProps) {
 	return (
 		<ArkMenu.Root
 			{...rootProps}
-			className={className}
 			onSelect={(details) => onSelect?.(details.value)}
 			positioning={{
 				...defaultSubPosition,
@@ -29,7 +30,13 @@ export function MenuSub(props: MenuSubProps) {
 			}}
 			data-testid={tid("--sub-root")}
 		>
-			{children}
+			{className !== undefined ? (
+				<Box className={className} testId={tid("--sub-inner")}>
+					{children}
+				</Box>
+			) : (
+				children
+			)}
 		</ArkMenu.Root>
 	);
 }

--- a/packages/react/src/components/menu/MenuSubContent.tsx
+++ b/packages/react/src/components/menu/MenuSubContent.tsx
@@ -4,9 +4,7 @@ import type React from "react";
 import { Portal } from "@ark-ui/react/portal";
 import { testId as testIdFn } from "@temporal-ui/core/utils/string";
 
-export interface MenuSubContentProps
-	extends CoreMenuSubContentProps,
-		React.ComponentProps<typeof ArkMenu.Content> {}
+export interface MenuSubContentProps extends CoreMenuSubContentProps, React.ComponentProps<typeof ArkMenu.Content> {}
 
 export function MenuSubContent(props: MenuSubContentProps) {
 	const { testId, className, children, ...rest } = props;

--- a/packages/react/src/components/menu/MenuSubContent.tsx
+++ b/packages/react/src/components/menu/MenuSubContent.tsx
@@ -1,0 +1,24 @@
+import type { MenuSubContentProps as CoreMenuSubContentProps } from "@temporal-ui/core/menu";
+import { Menu as ArkMenu } from "@ark-ui/react/menu";
+import type React from "react";
+import { Portal } from "@ark-ui/react/portal";
+import { testId as testIdFn } from "@temporal-ui/core/utils/string";
+
+export interface MenuSubContentProps
+	extends CoreMenuSubContentProps,
+		React.ComponentProps<typeof ArkMenu.Content> {}
+
+export function MenuSubContent(props: MenuSubContentProps) {
+	const { testId, className, children, ...rest } = props;
+	const tid = testIdFn(testId);
+
+	return (
+		<Portal>
+			<ArkMenu.Positioner data-testid={tid("--sub-positioner")}>
+				<ArkMenu.Content {...rest} className={className} data-testid={tid("--sub-content")}>
+					{children}
+				</ArkMenu.Content>
+			</ArkMenu.Positioner>
+		</Portal>
+	);
+}

--- a/packages/react/src/components/menu/MenuSubTrigger.tsx
+++ b/packages/react/src/components/menu/MenuSubTrigger.tsx
@@ -2,7 +2,8 @@ import type { MenuSubTriggerProps as CoreMenuSubTriggerProps } from "@temporal-u
 import { Menu as ArkMenu } from "@ark-ui/react/menu";
 import type React from "react";
 
-export interface MenuSubTriggerProps extends CoreMenuSubTriggerProps, React.ComponentProps<typeof ArkMenu.TriggerItem> {}
+export interface MenuSubTriggerProps
+	extends CoreMenuSubTriggerProps, React.ComponentProps<typeof ArkMenu.TriggerItem> {}
 
 export function MenuSubTrigger(props: MenuSubTriggerProps) {
 	const { testId, className, ...rest } = props;

--- a/packages/react/src/components/menu/MenuSubTrigger.tsx
+++ b/packages/react/src/components/menu/MenuSubTrigger.tsx
@@ -1,0 +1,15 @@
+import type { MenuSubTriggerProps as CoreMenuSubTriggerProps } from "@temporal-ui/core/menu";
+import { Menu as ArkMenu } from "@ark-ui/react/menu";
+import type React from "react";
+
+export interface MenuSubTriggerProps extends CoreMenuSubTriggerProps, React.ComponentProps<typeof ArkMenu.TriggerItem> {}
+
+export function MenuSubTrigger(props: MenuSubTriggerProps) {
+	const { testId, className, ...rest } = props;
+
+	return (
+		<ArkMenu.TriggerItem {...rest} className={className} data-testid={testId}>
+			{props.children}
+		</ArkMenu.TriggerItem>
+	);
+}

--- a/packages/react/src/components/menu/index.ts
+++ b/packages/react/src/components/menu/index.ts
@@ -5,3 +5,6 @@ export { MenuRadioItem, type MenuRadioItemProps } from "./MenuRadioItem";
 export { MenuRadioItemGroup, type MenuRadioItemGroupProps } from "./MenuRadioItemGroup";
 export { MenuItemGroup, type MenuItemGroupProps } from "./MenuItemGroup";
 export { MenuItemSeparator, type MenuItemSeparatorProps } from "./MenuItemSeparator";
+export { MenuSub, type MenuSubProps } from "./MenuSub";
+export { MenuSubTrigger, type MenuSubTriggerProps } from "./MenuSubTrigger";
+export { MenuSubContent, type MenuSubContentProps } from "./MenuSubContent";

--- a/packages/react/src/testing-library.d.ts
+++ b/packages/react/src/testing-library.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/@testing-library/jest-dom/types/vitest.d.ts" />

--- a/packages/solid/src/components/menu/Menu.integration.test.tsx
+++ b/packages/solid/src/components/menu/Menu.integration.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen, waitFor } from "@solidjs/testing-library";
 import userEvent from "@testing-library/user-event";
+import { ChevronRight } from "lucide-solid";
 import { Menu } from "./Menu";
 import { MenuCheckboxItem } from "./MenuCheckboxItem";
 import { MenuItem } from "./MenuItem";
@@ -7,6 +8,9 @@ import { MenuItemGroup } from "./MenuItemGroup";
 import { MenuItemSeparator } from "./MenuItemSeparator";
 import { MenuRadioItem } from "./MenuRadioItem";
 import { MenuRadioItemGroup } from "./MenuRadioItemGroup";
+import { MenuSub } from "./MenuSub";
+import { MenuSubContent } from "./MenuSubContent";
+import { MenuSubTrigger } from "./MenuSubTrigger";
 
 describe("Menu Integration Tests", () => {
 	beforeEach(() => {
@@ -113,5 +117,52 @@ describe("Menu Integration Tests", () => {
 
 		await user.click(radioItem);
 		expect(onRadioChange).toHaveBeenCalledWith("option2");
+	});
+
+	it("opens nested submenu and selects a submenu item", async () => {
+		const user = userEvent.setup();
+		const onRootSelect = vi.fn();
+		const onSubSelect = vi.fn();
+
+		render(() => (
+			<Menu
+				trigger={(props) => (
+					<button type="button" {...props}>
+						Nested Menu
+					</button>
+				)}
+				onSelect={onRootSelect}
+			>
+				<MenuItem value="top">Top action</MenuItem>
+				<MenuSub onSelect={onSubSelect}>
+					<MenuSubTrigger>
+						More
+						<ChevronRight aria-hidden />
+					</MenuSubTrigger>
+					<MenuSubContent>
+						<MenuItem value="nested-a">Nested A</MenuItem>
+						<MenuItem value="nested-b">Nested B</MenuItem>
+					</MenuSubContent>
+				</MenuSub>
+			</Menu>
+		));
+
+		await user.click(screen.getByRole("button", { name: "Nested Menu" }));
+
+		await waitFor(() => {
+			expect(screen.getByRole("menu")).toBeVisible();
+		});
+
+		const triggerItem = screen.getByRole("menuitem", { name: /More/i });
+		await user.click(triggerItem);
+
+		await waitFor(() => {
+			expect(screen.getByRole("menuitem", { name: "Nested A" })).toBeVisible();
+		});
+
+		await user.click(screen.getByRole("menuitem", { name: "Nested A" }));
+
+		expect(onSubSelect).toHaveBeenCalledWith("nested-a");
+		expect(onRootSelect).not.toHaveBeenCalled();
 	});
 });

--- a/packages/solid/src/components/menu/Menu.stories.tsx
+++ b/packages/solid/src/components/menu/Menu.stories.tsx
@@ -1,6 +1,6 @@
 // noinspection JSUnusedGlobalSymbols
 
-import { CreditCard, LogOut, Settings, UserIcon, UserPlus, UsersIcon } from "lucide-solid";
+import { ChevronRight, CreditCard, LogOut, Settings, UserIcon, UserPlus, UsersIcon } from "lucide-solid";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { fn } from "storybook/test";
 import { Button } from "../button";
@@ -11,6 +11,9 @@ import { MenuItemGroup } from "./MenuItemGroup";
 import { MenuItemSeparator } from "./MenuItemSeparator";
 import { MenuRadioItem } from "./MenuRadioItem";
 import { MenuRadioItemGroup } from "./MenuRadioItemGroup";
+import { MenuSub } from "./MenuSub";
+import { MenuSubContent } from "./MenuSubContent";
+import { MenuSubTrigger } from "./MenuSubTrigger";
 
 const meta = {
 	title: "Solid/Menu",
@@ -370,6 +373,40 @@ export const MixedItemTypes: Story = {
 	render: (props: MenuProps) => (
 		<Menu {...props}>
 			<SampleMixedMenuItems />
+		</Menu>
+	),
+};
+
+export const NestedSubmenus: Story = {
+	args: {
+		trigger: (props: Record<string, unknown>) => <SampleTrigger {...props} />,
+		onSelect: fn(),
+	},
+	render: (props: MenuProps) => (
+		<Menu {...props}>
+			<MenuItem value="profile">
+				<UserIcon />
+				My Profile
+			</MenuItem>
+			<MenuSub>
+				<MenuSubTrigger>
+					Invite member
+					<ChevronRight aria-hidden />
+				</MenuSubTrigger>
+				<MenuSubContent>
+					<MenuItem value="invite-email">By email</MenuItem>
+					<MenuItem value="invite-link">Share link</MenuItem>
+				</MenuSubContent>
+			</MenuSub>
+			<MenuItem value="settings">
+				<Settings />
+				Settings
+			</MenuItem>
+			<MenuItemSeparator />
+			<MenuItem value="logout">
+				<LogOut />
+				Log out
+			</MenuItem>
 		</Menu>
 	),
 };

--- a/packages/solid/src/components/menu/MenuSub.tsx
+++ b/packages/solid/src/components/menu/MenuSub.tsx
@@ -2,6 +2,7 @@ import { Menu as ArkMenu } from "@ark-ui/solid/menu";
 import type { MenuSubProps as CoreMenuSubProps } from "@temporal-ui/core/menu";
 import { testId } from "@temporal-ui/core/utils/string";
 import { splitProps, type ComponentProps, type JSX, type ParentProps } from "solid-js";
+import { Box } from "../box";
 
 const defaultSubPosition = {
 	placement: "right-start" as const,
@@ -9,7 +10,8 @@ const defaultSubPosition = {
 };
 
 export interface MenuSubProps
-	extends CoreMenuSubProps<JSX.Element>,
+	extends
+		CoreMenuSubProps<JSX.Element>,
 		Omit<ComponentProps<typeof ArkMenu.Root>, "positioning" | "children" | "onSelect">,
 		ParentProps {}
 
@@ -21,7 +23,6 @@ export function MenuSub(_props: MenuSubProps) {
 	return (
 		<ArkMenu.Root
 			{...rootProps}
-			class={localProps.className}
 			onSelect={(details) => localProps.onSelect?.(details.value)}
 			positioning={{
 				...defaultSubPosition,
@@ -29,7 +30,13 @@ export function MenuSub(_props: MenuSubProps) {
 			}}
 			data-testid={tid("--sub-root")}
 		>
-			{localProps.children}
+			{localProps.className !== undefined ? (
+				<Box class={localProps.className} testId={tid("--sub-inner")}>
+					{localProps.children}
+				</Box>
+			) : (
+				localProps.children
+			)}
 		</ArkMenu.Root>
 	);
 }

--- a/packages/solid/src/components/menu/MenuSub.tsx
+++ b/packages/solid/src/components/menu/MenuSub.tsx
@@ -1,0 +1,35 @@
+import { Menu as ArkMenu } from "@ark-ui/solid/menu";
+import type { MenuSubProps as CoreMenuSubProps } from "@temporal-ui/core/menu";
+import { testId } from "@temporal-ui/core/utils/string";
+import { splitProps, type ComponentProps, type JSX, type ParentProps } from "solid-js";
+
+const defaultSubPosition = {
+	placement: "right-start" as const,
+	gutter: -2,
+};
+
+export interface MenuSubProps
+	extends CoreMenuSubProps<JSX.Element>,
+		Omit<ComponentProps<typeof ArkMenu.Root>, "positioning" | "children" | "onSelect">,
+		ParentProps {}
+
+export function MenuSub(_props: MenuSubProps) {
+	const [localProps, rootProps] = splitProps(_props, ["className", "testId", "position", "children", "onSelect"]);
+
+	const tid = testId(localProps.testId);
+
+	return (
+		<ArkMenu.Root
+			{...rootProps}
+			class={localProps.className}
+			onSelect={(details) => localProps.onSelect?.(details.value)}
+			positioning={{
+				...defaultSubPosition,
+				...localProps.position,
+			}}
+			data-testid={tid("--sub-root")}
+		>
+			{localProps.children}
+		</ArkMenu.Root>
+	);
+}

--- a/packages/solid/src/components/menu/MenuSubContent.tsx
+++ b/packages/solid/src/components/menu/MenuSubContent.tsx
@@ -4,8 +4,7 @@ import { testId } from "@temporal-ui/core/utils/string";
 import { Portal } from "solid-js/web";
 import { splitProps, type ComponentProps } from "solid-js";
 
-export interface MenuSubContentProps
-	extends CoreMenuSubContentProps, ComponentProps<typeof ArkMenu.Content> {}
+export interface MenuSubContentProps extends CoreMenuSubContentProps, ComponentProps<typeof ArkMenu.Content> {}
 
 export function MenuSubContent(props: MenuSubContentProps) {
 	const [localProps, contentProps] = splitProps(props, ["className", "testId"]);

--- a/packages/solid/src/components/menu/MenuSubContent.tsx
+++ b/packages/solid/src/components/menu/MenuSubContent.tsx
@@ -1,0 +1,22 @@
+import { Menu as ArkMenu } from "@ark-ui/solid/menu";
+import type { MenuSubContentProps as CoreMenuSubContentProps } from "@temporal-ui/core/menu";
+import { testId } from "@temporal-ui/core/utils/string";
+import { Portal } from "solid-js/web";
+import { splitProps, type ComponentProps } from "solid-js";
+
+export interface MenuSubContentProps
+	extends CoreMenuSubContentProps, ComponentProps<typeof ArkMenu.Content> {}
+
+export function MenuSubContent(props: MenuSubContentProps) {
+	const [localProps, contentProps] = splitProps(props, ["className", "testId"]);
+
+	const tid = testId(localProps.testId);
+
+	return (
+		<Portal>
+			<ArkMenu.Positioner data-testid={tid("--sub-positioner")}>
+				<ArkMenu.Content {...contentProps} class={localProps.className} data-testid={tid("--sub-content")} />
+			</ArkMenu.Positioner>
+		</Portal>
+	);
+}

--- a/packages/solid/src/components/menu/MenuSubTrigger.tsx
+++ b/packages/solid/src/components/menu/MenuSubTrigger.tsx
@@ -1,0 +1,14 @@
+import { Menu as ArkMenu } from "@ark-ui/solid/menu";
+import type { MenuSubTriggerProps as CoreMenuSubTriggerProps } from "@temporal-ui/core/menu";
+import { splitProps, type ComponentProps } from "solid-js";
+
+export interface MenuSubTriggerProps
+	extends CoreMenuSubTriggerProps, ComponentProps<typeof ArkMenu.TriggerItem> {}
+
+export function MenuSubTrigger(props: MenuSubTriggerProps) {
+	const [localProps, triggerProps] = splitProps(props, ["className", "testId"]);
+
+	return (
+		<ArkMenu.TriggerItem {...triggerProps} class={localProps.className} data-testid={localProps.testId} />
+	);
+}

--- a/packages/solid/src/components/menu/MenuSubTrigger.tsx
+++ b/packages/solid/src/components/menu/MenuSubTrigger.tsx
@@ -2,13 +2,10 @@ import { Menu as ArkMenu } from "@ark-ui/solid/menu";
 import type { MenuSubTriggerProps as CoreMenuSubTriggerProps } from "@temporal-ui/core/menu";
 import { splitProps, type ComponentProps } from "solid-js";
 
-export interface MenuSubTriggerProps
-	extends CoreMenuSubTriggerProps, ComponentProps<typeof ArkMenu.TriggerItem> {}
+export interface MenuSubTriggerProps extends CoreMenuSubTriggerProps, ComponentProps<typeof ArkMenu.TriggerItem> {}
 
 export function MenuSubTrigger(props: MenuSubTriggerProps) {
 	const [localProps, triggerProps] = splitProps(props, ["className", "testId"]);
 
-	return (
-		<ArkMenu.TriggerItem {...triggerProps} class={localProps.className} data-testid={localProps.testId} />
-	);
+	return <ArkMenu.TriggerItem {...triggerProps} class={localProps.className} data-testid={localProps.testId} />;
 }

--- a/packages/solid/src/components/menu/index.ts
+++ b/packages/solid/src/components/menu/index.ts
@@ -5,3 +5,6 @@ export { MenuRadioItem, type MenuRadioItemProps } from "./MenuRadioItem";
 export { MenuRadioItemGroup, type MenuRadioItemGroupProps } from "./MenuRadioItemGroup";
 export { MenuItemGroup, type MenuItemGroupProps } from "./MenuItemGroup";
 export { MenuItemSeparator, type MenuItemSeparatorProps } from "./MenuItemSeparator";
+export { MenuSub, type MenuSubProps } from "./MenuSub";
+export { MenuSubTrigger, type MenuSubTriggerProps } from "./MenuSubTrigger";
+export { MenuSubContent, type MenuSubContentProps } from "./MenuSubContent";

--- a/packages/solid/src/testing-library.d.ts
+++ b/packages/solid/src/testing-library.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../node_modules/@testing-library/jest-dom/types/vitest.d.ts" />

--- a/packages/solid/vite.config.mts
+++ b/packages/solid/vite.config.mts
@@ -11,6 +11,6 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: "jsdom",
-		setupFiles: ["./vitest.setup.ts"],
+		setupFiles: "./vitest.setup.ts",
 	},
 });

--- a/packages/solid/vitest.setup.ts
+++ b/packages/solid/vitest.setup.ts
@@ -1,9 +1,9 @@
-import "@testing-library/jest-dom/vitest";
-
-class ResizeObserver {
-	observe() {}
-	unobserve() {}
-	disconnect() {}
+/** jsdom does not provide ResizeObserver; Ark positioning uses it asynchronously after unmount. */
+class ResizeObserverStub {
+	observe(): void {}
+	unobserve(): void {}
+	disconnect(): void {}
 }
+globalThis.ResizeObserver = ResizeObserverStub;
 
-globalThis.ResizeObserver = ResizeObserver;
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements nested menus using Ark UI’s nested `Menu.Root` + `Menu.TriggerItem` pattern (same as [Ark’s nested menu example](https://ark-ui.com/examples/nested-menu)).

### API

- **`MenuSub`** — submenu root; defaults `positioning` to `placement: right-start`, `gutter: -2`; supports optional `onSelect` for submenu selections (mirrors top-level `Menu`). Optional **`className`** applies via an inner **`Box`** wrapper (Ark `Menu.Root` does not accept `className`).
- **`MenuSubTrigger`** — wraps Ark `TriggerItem` for the row that opens the child menu.
- **`MenuSubContent`** — portals `Positioner` + `Content` so submenu panels align with Ark’s positioning behavior.

### Other

- Core `menu.css`: styles `[data-part="trigger-item"]` alongside regular items.
- React & Solid: **`NestedSubmenus`** Storybook story and integration test (open submenu via click, select nested item, assert `onSubSelect` vs root `onSelect`).
- **`testing-library.d.ts`** (React/Solid): triple-slash reference to `@testing-library/jest-dom`’s `vitest.d.ts` so **`tsgo`** merges jest-dom matchers into Vitest’s `Assertion` (fixes local typecheck parity with CI).
- Solid **`vitest.setup.ts`**: **`ResizeObserver`** stub for jsdom (required when menus use positioning) plus jest-dom setup.

Closes **TPX-470**.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-470](https://linear.app/temporal1/issue/TPX-470/implement-nested-menus-from-arkui)

<div><a href="https://cursor.com/agents/bc-1df007d0-ff5a-4fe0-abd5-4bbafcb0829b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1df007d0-ff5a-4fe0-abd5-4bbafcb0829b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

