### PR TITLE
fix(sidebar): TPX-494 inset/floating icon collapsed width

### DIFF
--- a/.changeset/sidebar-inset-icon-width.md
+++ b/.changeset/sidebar-inset-icon-width.md
@@ -1,0 +1,7 @@
+---
+"@temporal-ui/core": patch
+"@temporal-ui/react": patch
+"@temporal-ui/solid": patch
+---
+
+Fix invalid `calc()` for sidebar gap and container when `variant` is `inset` or `floating` and `collapsible` is `icon`, so the collapsed rail width is applied and main content no longer slides under the sidebar.

--- a/packages/core/src/components/sidebar/sidebar.css
+++ b/packages/core/src/components/sidebar/sidebar.css
@@ -17,7 +17,10 @@
 
 			&[data-variant="floating"],
 			&[data-variant="inset"] {
-				@apply group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)];
+				/* avoid @apply w-[calc(...)] here: the bundler can drop `+` and break `calc()` */
+				.group[data-collapsible="icon"] & {
+					width: calc(var(--sidebar-width-icon) + var(--spacing) * 4 + 2px);
+				}
 			}
 
 			&[data-variant="sidebar"] {
@@ -38,7 +41,11 @@
 
 			&[data-variant="floating"],
 			&[data-variant="inset"] {
-				@apply p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)];
+				@apply p-2;
+
+				.group[data-collapsible="icon"] & {
+					width: calc(var(--sidebar-width-icon) + var(--spacing) * 4 + 2px);
+				}
 			}
 
 			&[data-variant="sidebar"] {

--- a/packages/react/src/components/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/sidebar/Sidebar.stories.tsx
@@ -77,3 +77,22 @@ export const Default: Story = {
 		</Box>
 	),
 };
+
+export const Inset: Story = {
+	args: {
+		side: "left",
+		variant: "inset",
+		collapsible: "icon",
+	},
+	render: (args) => (
+		<Box className="">
+			<SidebarProvider className="">
+				<AppSidebar {...args} />
+				<SidebarInset>
+					<SidebarTrigger />
+					{args.children}
+				</SidebarInset>
+			</SidebarProvider>
+		</Box>
+	),
+};

--- a/packages/solid/src/components/sidebar/Sidebar.stories.tsx
+++ b/packages/solid/src/components/sidebar/Sidebar.stories.tsx
@@ -77,3 +77,22 @@ export const Default: Story = {
 		</Box>
 	),
 };
+
+export const Inset: Story = {
+	args: {
+		side: "left",
+		variant: "inset",
+		collapsible: "icon",
+	},
+	render: (args: SidebarProps) => (
+		<Box class="">
+			<SidebarProvider class="">
+				<AppSidebar {...args} />
+				<SidebarInset>
+					<SidebarTrigger />
+					{args.children}
+				</SidebarInset>
+			</SidebarProvider>
+		</Box>
+	),
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **TPX-494**: when `Sidebar` uses `variant="inset"` or `"floating"` with `collapsible="icon"`, the collapsed rail width was never applied because invalid CSS was emitted from arbitrary `calc()` inside `@apply` (operators like `+` could be stripped during bundling; the original `(--spacing(4))` form was also invalid).

## Changes

- **`packages/core/src/components/sidebar/sidebar.css`**: For `data-slot="gap"` and `data-slot="container"` under inset/floating, set `width` with plain CSS under `.group[data-collapsible="icon"]` using  
  `calc(var(--sidebar-width-icon) + var(--spacing) * 4 + 2px)` so shipped `styles.css` stays valid.
- **Storybook**: added **`Inset`** stories for React and Solid (`variant="inset"`, `collapsible="icon"`).
- **Changeset**: patch bump for `@temporal-ui/core`, `@temporal-ui/react`, `@temporal-ui/solid`.

## Testing

- `bun run build`, `bun run lint`, `bun run typecheck`, `bun run test`

Sidebar unit tests unchanged; they do not assert computed layout widths.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-494](https://linear.app/temporal1/issue/TPX-494/sidebar-collapse-state-issue-with-inset-variant)

<div><a href="https://cursor.com/agents/bc-f949d890-295f-4629-9c9d-b6d002aeb505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f949d890-295f-4629-9c9d-b6d002aeb505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

