### PR TITLE
feat(avatar): colored default avatars (TPX-508)

### DIFF
--- a/.changeset/tpx-508-avatar-colors.md
+++ b/.changeset/tpx-508-avatar-colors.md
@@ -1,0 +1,7 @@
+---
+"@temporal-ui/core": patch
+"@temporal-ui/react": patch
+"@temporal-ui/solid": patch
+---
+
+Add deterministic accent backgrounds for `Avatar` initials fallback via `color` prop (including default `auto`), Tailwind-based palette tokens with light/dark support, and `data-color` CSS hooks. Rewrite Avatar on Ark UI primitives without Solid image status-sync workaround.

--- a/packages/core/src/components/avatar/avatar.css
+++ b/packages/core/src/components/avatar/avatar.css
@@ -2,8 +2,23 @@
 	.avatar,
 	.avatar-sm,
 	.avatar-lg {
-		@apply size-8 shrink-0 object-cover rounded-full border-1 bg-muted flex items-center justify-center text-primary overflow-hidden;
+		@apply relative box-border size-8 shrink-0 overflow-hidden rounded-full border-1 bg-transparent;
 	}
+
+	.avatar [data-part="image"],
+	.avatar-sm [data-part="image"],
+	.avatar-lg [data-part="image"] {
+		@apply absolute inset-0 size-full object-cover;
+	}
+
+	.avatar [data-part="fallback"],
+	.avatar-sm [data-part="fallback"],
+	.avatar-lg [data-part="fallback"] {
+		@apply absolute inset-0 flex size-full items-center justify-center font-medium;
+		background-color: var(--avatar-bg, var(--color-muted));
+		color: var(--avatar-fg, var(--color-primary));
+	}
+
 	/* Lucide (and similar) icons default to a fixed 24px; scale nested svg with avatar size */
 	.avatar {
 		@apply [&_svg]:size-5 [&_svg]:shrink-0;
@@ -13,5 +28,107 @@
 	}
 	.avatar-lg {
 		@apply size-10 text-lg [&_svg]:size-6 [&_svg]:shrink-0;
+	}
+
+	/*
+	 * Palette tokens live on the root so consumers can override per variant; only the fallback
+	 * consumes `--avatar-bg` / `--avatar-fg` (see selectors above).
+	 */
+	.avatar[data-color="red"] {
+		--avatar-bg: var(--avatar-color-red-bg-light);
+		--avatar-fg: var(--avatar-color-red-fg-light);
+	}
+	.avatar[data-color="orange"] {
+		--avatar-bg: var(--avatar-color-orange-bg-light);
+		--avatar-fg: var(--avatar-color-orange-fg-light);
+	}
+	.avatar[data-color="amber"] {
+		--avatar-bg: var(--avatar-color-amber-bg-light);
+		--avatar-fg: var(--avatar-color-amber-fg-light);
+	}
+	.avatar[data-color="yellow"] {
+		--avatar-bg: var(--avatar-color-yellow-bg-light);
+		--avatar-fg: var(--avatar-color-yellow-fg-light);
+	}
+	.avatar[data-color="lime"] {
+		--avatar-bg: var(--avatar-color-lime-bg-light);
+		--avatar-fg: var(--avatar-color-lime-fg-light);
+	}
+	.avatar[data-color="green"] {
+		--avatar-bg: var(--avatar-color-green-bg-light);
+		--avatar-fg: var(--avatar-color-green-fg-light);
+	}
+	.avatar[data-color="teal"] {
+		--avatar-bg: var(--avatar-color-teal-bg-light);
+		--avatar-fg: var(--avatar-color-teal-fg-light);
+	}
+	.avatar[data-color="cyan"] {
+		--avatar-bg: var(--avatar-color-cyan-bg-light);
+		--avatar-fg: var(--avatar-color-cyan-fg-light);
+	}
+	.avatar[data-color="blue"] {
+		--avatar-bg: var(--avatar-color-blue-bg-light);
+		--avatar-fg: var(--avatar-color-blue-fg-light);
+	}
+	.avatar[data-color="violet"] {
+		--avatar-bg: var(--avatar-color-violet-bg-light);
+		--avatar-fg: var(--avatar-color-violet-fg-light);
+	}
+	.avatar[data-color="purple"] {
+		--avatar-bg: var(--avatar-color-purple-bg-light);
+		--avatar-fg: var(--avatar-color-purple-fg-light);
+	}
+	.avatar[data-color="pink"] {
+		--avatar-bg: var(--avatar-color-pink-bg-light);
+		--avatar-fg: var(--avatar-color-pink-fg-light);
+	}
+
+	.dark .avatar[data-color="red"] {
+		--avatar-bg: var(--avatar-color-red-bg-dark);
+		--avatar-fg: var(--avatar-color-red-fg-dark);
+	}
+	.dark .avatar[data-color="orange"] {
+		--avatar-bg: var(--avatar-color-orange-bg-dark);
+		--avatar-fg: var(--avatar-color-orange-fg-dark);
+	}
+	.dark .avatar[data-color="amber"] {
+		--avatar-bg: var(--avatar-color-amber-bg-dark);
+		--avatar-fg: var(--avatar-color-amber-fg-dark);
+	}
+	.dark .avatar[data-color="yellow"] {
+		--avatar-bg: var(--avatar-color-yellow-bg-dark);
+		--avatar-fg: var(--avatar-color-yellow-fg-dark);
+	}
+	.dark .avatar[data-color="lime"] {
+		--avatar-bg: var(--avatar-color-lime-bg-dark);
+		--avatar-fg: var(--avatar-color-lime-fg-dark);
+	}
+	.dark .avatar[data-color="green"] {
+		--avatar-bg: var(--avatar-color-green-bg-dark);
+		--avatar-fg: var(--avatar-color-green-fg-dark);
+	}
+	.dark .avatar[data-color="teal"] {
+		--avatar-bg: var(--avatar-color-teal-bg-dark);
+		--avatar-fg: var(--avatar-color-teal-fg-dark);
+	}
+	.dark .avatar[data-color="cyan"] {
+		--avatar-bg: var(--avatar-color-cyan-bg-dark);
+		--avatar-fg: var(--avatar-color-cyan-fg-dark);
+	}
+	.dark .avatar[data-color="blue"] {
+		--avatar-bg: var(--avatar-color-blue-bg-dark);
+		--avatar-fg: var(--avatar-color-blue-fg-dark);
+	}
+	.dark .avatar[data-color="violet"] {
+		--avatar-bg: var(--avatar-color-violet-bg-dark);
+		--avatar-fg: var(--avatar-color-violet-fg-dark);
+	}
+	.dark .avatar[data-color="purple"] {
+		--avatar-bg: var(--avatar-color-purple-bg-dark);
+		--avatar-fg: var(--avatar-color-purple-fg-dark);
+	}
+	.dark .avatar[data-color="pink"] {
+		--avatar-bg: var(--avatar-color-pink-bg-dark);
+		--avatar-fg: var(--avatar-color-pink-fg-dark);
 	}
 }

--- a/packages/core/src/components/avatar/avatar.ts
+++ b/packages/core/src/components/avatar/avatar.ts
@@ -1,12 +1,25 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { BaseComponent } from "../base";
+import type { AvatarColorProp } from "../../utils/avatar-variant";
+
+export type { AvatarColorProp } from "../../utils/avatar-variant";
 
 export interface AvatarProps extends BaseComponent<never> {
 	/** The size of the avatar */
 	size?: "sm" | "md" | "lg";
-	/** The name of the avatar */
+	/**
+	 * Display name used for initials when no image is shown. When `color` is `"auto"` (default),
+	 * a stable accent palette is chosen from this string; whitespace-only or missing values use
+	 * the neutral fallback (`data-color="none"`).
+	 */
 	name?: string;
 	/** The URL of the avatar */
 	src?: string;
+	/**
+	 * Accent palette for the initials/icon fallback. `"auto"` derives a stable variant from `name`.
+	 * `"none"` keeps the neutral muted fallback. Ignored for background once a photo loads successfully.
+	 * @default 'auto'
+	 */
+	color?: AvatarColorProp;
 }

--- a/packages/core/src/components/avatar/avatar.ts
+++ b/packages/core/src/components/avatar/avatar.ts
@@ -5,6 +5,8 @@ import type { AvatarColorProp } from "../../utils/avatar-variant";
 
 export type { AvatarColorProp } from "../../utils/avatar-variant";
 
+export type AvatarColorVariant = AvatarColorProp;
+
 export interface AvatarProps extends BaseComponent<never> {
 	/** The size of the avatar */
 	size?: "sm" | "md" | "lg";

--- a/packages/core/src/css/theme.css
+++ b/packages/core/src/css/theme.css
@@ -35,6 +35,56 @@
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
 
+	/* Avatar fallback accents — bg/fg pairs target WCAG AA ≥ 4.5:1 (Tailwind default palette) */
+	--avatar-color-red-bg-light: var(--color-red-200);
+	--avatar-color-red-fg-light: var(--color-red-950);
+	--avatar-color-red-bg-dark: var(--color-red-950);
+	--avatar-color-red-fg-dark: var(--color-red-50);
+	--avatar-color-orange-bg-light: var(--color-orange-200);
+	--avatar-color-orange-fg-light: var(--color-orange-950);
+	--avatar-color-orange-bg-dark: var(--color-orange-950);
+	--avatar-color-orange-fg-dark: var(--color-orange-50);
+	--avatar-color-amber-bg-light: var(--color-amber-200);
+	--avatar-color-amber-fg-light: var(--color-amber-950);
+	--avatar-color-amber-bg-dark: var(--color-amber-950);
+	--avatar-color-amber-fg-dark: var(--color-amber-50);
+	--avatar-color-yellow-bg-light: var(--color-yellow-300);
+	--avatar-color-yellow-fg-light: var(--color-yellow-950);
+	--avatar-color-yellow-bg-dark: var(--color-yellow-950);
+	--avatar-color-yellow-fg-dark: var(--color-yellow-50);
+	--avatar-color-lime-bg-light: var(--color-lime-200);
+	--avatar-color-lime-fg-light: var(--color-lime-950);
+	--avatar-color-lime-bg-dark: var(--color-lime-950);
+	--avatar-color-lime-fg-dark: var(--color-lime-50);
+	--avatar-color-green-bg-light: var(--color-green-200);
+	--avatar-color-green-fg-light: var(--color-green-950);
+	--avatar-color-green-bg-dark: var(--color-green-950);
+	--avatar-color-green-fg-dark: var(--color-green-50);
+	--avatar-color-teal-bg-light: var(--color-teal-200);
+	--avatar-color-teal-fg-light: var(--color-teal-950);
+	--avatar-color-teal-bg-dark: var(--color-teal-950);
+	--avatar-color-teal-fg-dark: var(--color-teal-50);
+	--avatar-color-cyan-bg-light: var(--color-cyan-200);
+	--avatar-color-cyan-fg-light: var(--color-cyan-950);
+	--avatar-color-cyan-bg-dark: var(--color-cyan-950);
+	--avatar-color-cyan-fg-dark: var(--color-cyan-50);
+	--avatar-color-blue-bg-light: var(--color-blue-200);
+	--avatar-color-blue-fg-light: var(--color-blue-950);
+	--avatar-color-blue-bg-dark: var(--color-blue-950);
+	--avatar-color-blue-fg-dark: var(--color-blue-50);
+	--avatar-color-violet-bg-light: var(--color-violet-200);
+	--avatar-color-violet-fg-light: var(--color-violet-950);
+	--avatar-color-violet-bg-dark: var(--color-violet-950);
+	--avatar-color-violet-fg-dark: var(--color-violet-50);
+	--avatar-color-purple-bg-light: var(--color-purple-200);
+	--avatar-color-purple-fg-light: var(--color-purple-950);
+	--avatar-color-purple-bg-dark: var(--color-purple-950);
+	--avatar-color-purple-fg-dark: var(--color-purple-50);
+	--avatar-color-pink-bg-light: var(--color-pink-200);
+	--avatar-color-pink-fg-light: var(--color-pink-950);
+	--avatar-color-pink-bg-dark: var(--color-pink-950);
+	--avatar-color-pink-fg-dark: var(--color-pink-50);
+
 	--animate-fade-in: fadeIn 0.15s ease-in-out;
 	@keyframes fadeIn {
 		0% {

--- a/packages/core/src/utils/avatar-variant/avatar-variant.test.ts
+++ b/packages/core/src/utils/avatar-variant/avatar-variant.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant, resolveAvatarDataColor } from "./index";
+
+describe("getAvatarVariant", () => {
+	it("is pure and deterministic for the same input", () => {
+		const inputs = ["Ada Lovelace", "你好", "Émile", "x"];
+		for (const s of inputs) {
+			expect(getAvatarVariant(s, 12)).toBe(getAvatarVariant(s, 12));
+			expect(getAvatarVariant(s, 12)).toBe(getAvatarVariant(s, 12));
+		}
+	});
+
+	it("maps into [0, variantCount)", () => {
+		for (let i = 0; i < 500; i++) {
+			const v = getAvatarVariant(`user-${i}`, 12);
+			expect(v).toBeGreaterThanOrEqual(0);
+			expect(v).toBeLessThan(12);
+		}
+	});
+
+	it("every variant index is reachable for some input string", () => {
+		for (let target = 0; target < AVATAR_COLOR_VARIANTS.length; target++) {
+			let found = false;
+			for (let i = 0; i < 500_000 && !found; i++) {
+				if (getAvatarVariant(`reach-${i}`, AVATAR_COLOR_VARIANTS.length) === target) {
+					found = true;
+				}
+			}
+			expect(found).toBe(true);
+		}
+	});
+});
+
+describe("resolveAvatarDataColor", () => {
+	it('uses data-color "none" for color none and missing/empty name with auto', () => {
+		expect(resolveAvatarDataColor(undefined, "none")).toBe("none");
+		expect(resolveAvatarDataColor("", "auto")).toBe("none");
+		expect(resolveAvatarDataColor("   ", "auto")).toBe("none");
+		expect(resolveAvatarDataColor(undefined, "auto")).toBe("none");
+	});
+
+	it("uses explicit color without hashing", () => {
+		expect(resolveAvatarDataColor(undefined, "purple")).toBe("purple");
+		expect(resolveAvatarDataColor("Ignored Name", "cyan")).toBe("cyan");
+	});
+
+	it("auto derives from trimmed name", () => {
+		const v = resolveAvatarDataColor("  Jane Doe  ", "auto");
+		expect(AVATAR_COLOR_VARIANTS).toContain(v);
+		expect(v).toBe(resolveAvatarDataColor("Jane Doe", "auto"));
+	});
+});

--- a/packages/core/src/utils/avatar-variant/index.ts
+++ b/packages/core/src/utils/avatar-variant/index.ts
@@ -1,0 +1,59 @@
+/** Ordered list of palette names; index order must stay stable for hashing. */
+export const AVATAR_COLOR_VARIANTS = [
+	"red",
+	"orange",
+	"amber",
+	"yellow",
+	"lime",
+	"green",
+	"teal",
+	"cyan",
+	"blue",
+	"violet",
+	"purple",
+	"pink",
+] as const;
+
+export type AvatarNamedColorVariant = (typeof AVATAR_COLOR_VARIANTS)[number];
+
+export type AvatarColorProp = AvatarNamedColorVariant | "auto" | "none";
+
+/**
+ * Pure, deterministic hash mapping a non-empty string to `[0, variantCount)`.
+ * SSR-safe: same input always yields the same output (unsigned 32-bit FNV-style loop).
+ */
+export function getAvatarVariant(name: string, variantCount: number): number {
+	let hash = 0;
+	for (const char of name) {
+		hash = (hash * 31 + char.codePointAt(0)!) >>> 0;
+	}
+	return hash % variantCount;
+}
+
+/** Resolved `data-color` value for the avatar root (`none` or a named variant). */
+export type AvatarResolvedDataColor = AvatarNamedColorVariant | "none";
+
+/**
+ * Resolves which named palette applies for `data-color` on the avatar root.
+ * - `color === 'none'` → `'none'`
+ * - explicit named color → that variant
+ * - `color === 'auto'` (default) → hash from trimmed `name`, or `'none'` if no usable name
+ */
+export function resolveAvatarDataColor(
+	name: string | undefined,
+	color: AvatarColorProp | undefined,
+): AvatarResolvedDataColor {
+	const mode = color ?? "auto";
+	if (mode === "none") {
+		return "none";
+	}
+	if (mode === "auto") {
+		const trimmed = name?.trim() ?? "";
+		if (!trimmed) {
+			return "none";
+		}
+		const index = getAvatarVariant(trimmed, AVATAR_COLOR_VARIANTS.length);
+		return AVATAR_COLOR_VARIANTS[index]!;
+	}
+	return mode;
+}

--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -1,8 +1,28 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/utils/avatar-variant";
 import { Stack } from "../stack";
 import { Avatar } from "./Avatar";
+
+/** One sample name per palette slot so `color="auto"` exercises every hash bucket in stories. */
+const AUTO_COLOR_SAMPLE_NAMES: string[] = (() => {
+	const names: string[] = [];
+	for (let target = 0; target < AVATAR_COLOR_VARIANTS.length; target++) {
+		let picked: string | undefined;
+		for (let i = 0; i < 500_000 && !picked; i++) {
+			const s = `story-auto-${i}`;
+			if (getAvatarVariant(s, AVATAR_COLOR_VARIANTS.length) === target) {
+				picked = s;
+			}
+		}
+		if (!picked) {
+			throw new Error(`Could not find a name mapping to variant index ${target}`);
+		}
+		names.push(picked);
+	}
+	return names;
+})();
 
 const meta = {
 	title: "React/Avatar",
@@ -12,6 +32,10 @@ const meta = {
 		size: {
 			control: "radio",
 			options: ["sm", "md", "lg"],
+		},
+		color: {
+			control: "select",
+			options: [...AVATAR_COLOR_VARIANTS, "auto", "none"],
 		},
 	},
 } satisfies Meta<typeof Avatar>;
@@ -103,4 +127,82 @@ export const FallbackIconScalingByClass: Story = {
 			</Stack>
 		</Stack>
 	),
+};
+
+export const ColorVariants: Story = {
+	render: () => (
+		<Stack gap={8}>
+			<Stack gap={2}>
+				<p className="text-sm font-medium text-foreground">Explicit color (initials)</p>
+				<Stack row gap={3} align="flex-end" className="flex-wrap">
+					{AVATAR_COLOR_VARIANTS.map((c) => (
+						<Stack key={c} gap={1} align="center">
+							<Avatar name="Alex" color={c} testId={`avatar-explicit-${c}`} />
+							<span className="max-w-16 text-center text-xs text-muted-foreground">{c}</span>
+						</Stack>
+					))}
+				</Stack>
+			</Stack>
+			<Stack gap={2}>
+				<p className="text-sm font-medium text-foreground">Auto color (unique names per bucket)</p>
+				<Stack row gap={3} align="flex-end" className="flex-wrap">
+					{AVATAR_COLOR_VARIANTS.map((c, i) => (
+						<Stack key={`auto-${c}`} gap={1} align="center">
+							<Avatar name={AUTO_COLOR_SAMPLE_NAMES[i]} color="auto" testId={`avatar-auto-${c}`} />
+							<span className="max-w-20 text-center text-xs text-muted-foreground">{c}</span>
+						</Stack>
+					))}
+				</Stack>
+			</Stack>
+		</Stack>
+	),
+};
+
+export const DarkMode: Story = {
+	render: () => (
+		<div className="dark bg-background p-6">
+			<Stack gap={4}>
+				<p className="text-sm text-muted-foreground">Twelve explicit variants under .dark</p>
+				<Stack row gap={3} align="flex-end" className="flex-wrap">
+					{AVATAR_COLOR_VARIANTS.map((c) => (
+						<Stack key={c} gap={1} align="center">
+							<Avatar name="Riley" color={c} testId={`avatar-dark-${c}`} />
+							<span className="max-w-16 text-center text-xs text-muted-foreground">{c}</span>
+						</Stack>
+					))}
+				</Stack>
+			</Stack>
+		</div>
+	),
+};
+
+/** No name + auto → neutral (`data-color="none"`). */
+export const NoNameAutoNeutral: Story = {
+	args: {
+		color: "auto",
+	},
+};
+
+export const ColorNoneNeutral: Story = {
+	args: {
+		name: "Ignored",
+		color: "none",
+	},
+};
+
+/** Strong fallback color should not show once the photo has loaded. */
+export const ImageOverridesColoredFallback: Story = {
+	args: {
+		name: "Jamie Cook",
+		color: "pink",
+		src: "https://i.pravatar.cc/300",
+	},
+};
+
+export const BrokenImageUsesFallback: Story = {
+	args: {
+		name: "Sam Error",
+		color: "teal",
+		src: "https://invalid.invalid/not-a-real-image.png",
+	},
 };

--- a/packages/react/src/components/avatar/Avatar.test.tsx
+++ b/packages/react/src/components/avatar/Avatar.test.tsx
@@ -1,31 +1,30 @@
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AVATAR_COLOR_VARIANTS } from "@temporal-ui/core/utils/avatar-variant";
-import { For } from "solid-js";
 import { Avatar } from "./Avatar";
 
 describe("Avatar", () => {
 	it.each(AVATAR_COLOR_VARIANTS)("sets data-color=%s on root for explicit color", (variant) => {
-		render(() => <Avatar name="Test" color={variant} testId="av" />);
+		render(<Avatar name="Test" color={variant} testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", variant);
 	});
 
 	it('sets data-color="none" for color="none"', () => {
-		render(() => <Avatar name="N" color="none" testId="av" />);
+		render(<Avatar name="N" color="none" testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", "none");
 	});
 
 	it('sets data-color="none" when name is empty and color is auto', () => {
-		render(() => <Avatar name="" color="auto" testId="av" />);
+		render(<Avatar name="" color="auto" testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", "none");
 	});
 
 	it("explicit color overrides hash", () => {
-		render(() => <Avatar name="Alice" color="orange" testId="av" />);
+		render(<Avatar name="Alice" color="orange" testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", "orange");
 	});
 
-	it("hides fallback when image is already decoded", async () => {
+	it("hides fallback when image is already decoded (no colored fallback visible)", async () => {
 		const completeDesc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "complete");
 		const naturalWidthDesc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "naturalWidth");
 		const naturalHeightDesc = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "naturalHeight");
@@ -50,7 +49,7 @@ describe("Avatar", () => {
 		});
 
 		try {
-			render(() => <Avatar src="https://example.com/a.png" name="Jane" color="pink" testId="av" />);
+			render(<Avatar src="https://example.com/a.png" name="Jane" color="pink" testId="av" />);
 			await waitFor(() => {
 				expect(screen.getByTestId("av--fallback")).toHaveAttribute("hidden");
 			});
@@ -59,32 +58,5 @@ describe("Avatar", () => {
 			if (naturalWidthDesc) Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", naturalWidthDesc);
 			if (naturalHeightDesc) Object.defineProperty(HTMLImageElement.prototype, "naturalHeight", naturalHeightDesc);
 		}
-	});
-
-	it("snapshot of resolved data-color values for explicit variants", () => {
-		render(() => (
-			<div data-testid="avatar-table">
-				<For each={AVATAR_COLOR_VARIANTS}>
-					{(variant) => <Avatar name="Pat" color={variant} testId={`root-${variant}`} />}
-				</For>
-			</div>
-		));
-		const attrs = [...AVATAR_COLOR_VARIANTS].map((v) => screen.getByTestId(`root-${v}`).getAttribute("data-color"));
-		expect(attrs).toMatchInlineSnapshot(`
-			[
-			  "red",
-			  "orange",
-			  "amber",
-			  "yellow",
-			  "lime",
-			  "green",
-			  "teal",
-			  "cyan",
-			  "blue",
-			  "violet",
-			  "purple",
-			  "pink",
-			]
-		`);
 	});
 });

--- a/packages/react/src/components/avatar/Avatar.tsx
+++ b/packages/react/src/components/avatar/Avatar.tsx
@@ -2,19 +2,38 @@ import { Avatar as ArkAvatar } from "@ark-ui/react/avatar";
 import { UserIcon } from "lucide-react";
 import { forwardRef } from "react";
 import type { AvatarProps as AvatarPropsCore } from "@temporal-ui/core/avatar";
+import { resolveAvatarDataColor } from "@temporal-ui/core/utils/avatar-variant";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { getInitials } from "@temporal-ui/core/utils/string";
 
 export interface AvatarProps extends AvatarPropsCore {}
 
+/**
+ * Avatar shows a photo when `src` loads successfully; otherwise it shows initials from `name`, or a
+ * default user icon when initials are empty. When `color` is `"auto"` (default), the fallback
+ * background is a deterministic accent derived from `name` (hash); omit `name`, use only
+ * whitespace, or set `color` to `"none"` for the neutral muted fallback. Accent styles apply only
+ * to the fallback layer — they do not show behind a loaded image.
+ */
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps & ArkAvatar.RootProps>((props, ref) => {
-	const { name, src, className, testId, ...rootProps } = props;
+	const { name, src, color = "auto", className, testId, ...rootProps } = props;
 	const size = props.size !== "md" ? props.size : "";
 	const baseClass = ["avatar", size].filter(Boolean).join("-");
+	const dataColor = resolveAvatarDataColor(name, color);
 	return (
-		<ArkAvatar.Root ref={ref} className={cx(baseClass, className)} data-testid={testId} {...rootProps}>
-			<ArkAvatar.Fallback>{getInitials(name) || <UserIcon />}</ArkAvatar.Fallback>
+		<ArkAvatar.Root
+			ref={ref}
+			className={cx(baseClass, className)}
+			data-testid={testId}
+			data-color={dataColor}
+			{...rootProps}
+		>
 			<ArkAvatar.Image src={src} alt={name} data-testid={testId ? `${testId}--image` : undefined} />
+			<ArkAvatar.Fallback data-testid={testId ? `${testId}--fallback` : undefined}>
+				{getInitials(name ?? "") || <UserIcon />}
+			</ArkAvatar.Fallback>
 		</ArkAvatar.Root>
 	);
 });
+
+Avatar.displayName = "Avatar";

--- a/packages/solid/src/components/avatar/Avatar.stories.tsx
+++ b/packages/solid/src/components/avatar/Avatar.stories.tsx
@@ -1,8 +1,29 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/utils/avatar-variant";
+import { Index } from "solid-js";
 import { Stack } from "../stack";
 import { Avatar } from "./Avatar";
+
+/** One sample name per palette slot so `color="auto"` exercises every hash bucket in stories. */
+const AUTO_COLOR_SAMPLE_NAMES: string[] = (() => {
+	const names: string[] = [];
+	for (let target = 0; target < AVATAR_COLOR_VARIANTS.length; target++) {
+		let picked: string | undefined;
+		for (let i = 0; i < 500_000 && !picked; i++) {
+			const s = `story-auto-${i}`;
+			if (getAvatarVariant(s, AVATAR_COLOR_VARIANTS.length) === target) {
+				picked = s;
+			}
+		}
+		if (!picked) {
+			throw new Error(`Could not find a name mapping to variant index ${target}`);
+		}
+		names.push(picked);
+	}
+	return names;
+})();
 
 const meta = {
 	title: "Solid/Avatar",
@@ -12,6 +33,10 @@ const meta = {
 		size: {
 			control: "radio",
 			options: ["sm", "md", "lg"],
+		},
+		color: {
+			control: "select",
+			options: [...AVATAR_COLOR_VARIANTS, "auto", "none"],
 		},
 	},
 } satisfies Meta<typeof Avatar>;
@@ -103,4 +128,88 @@ export const FallbackIconScalingByClass: Story = {
 			</Stack>
 		</Stack>
 	),
+};
+
+export const ColorVariants: Story = {
+	render: () => (
+		<Stack gap={8}>
+			<Stack gap={2}>
+				<p class="text-sm font-medium text-foreground">Explicit color (initials)</p>
+				<Stack row gap={3} align="flex-end" class="flex-wrap">
+					<Index each={AVATAR_COLOR_VARIANTS}>
+						{(c) => (
+							<Stack gap={1} align="center">
+								<Avatar name="Alex" color={c()} testId={`avatar-explicit-${c()}`} />
+								<span class="max-w-16 text-center text-xs text-muted-foreground">{c()}</span>
+							</Stack>
+						)}
+					</Index>
+				</Stack>
+			</Stack>
+			<Stack gap={2}>
+				<p class="text-sm font-medium text-foreground">Auto color (unique names per bucket)</p>
+				<Stack row gap={3} align="flex-end" class="flex-wrap">
+					<Index each={AVATAR_COLOR_VARIANTS}>
+						{(c, i) => (
+							<Stack gap={1} align="center">
+								<Avatar name={AUTO_COLOR_SAMPLE_NAMES[i]} color="auto" testId={`avatar-auto-${c()}`} />
+								<span class="max-w-20 text-center text-xs text-muted-foreground">{c()}</span>
+							</Stack>
+						)}
+					</Index>
+				</Stack>
+			</Stack>
+		</Stack>
+	),
+};
+
+export const DarkMode: Story = {
+	render: () => (
+		<div class="dark bg-background p-6">
+			<Stack gap={4}>
+				<p class="text-sm text-muted-foreground">Twelve explicit variants under .dark</p>
+				<Stack row gap={3} align="flex-end" class="flex-wrap">
+					<Index each={AVATAR_COLOR_VARIANTS}>
+						{(c) => (
+							<Stack gap={1} align="center">
+								<Avatar name="Riley" color={c()} testId={`avatar-dark-${c()}`} />
+								<span class="max-w-16 text-center text-xs text-muted-foreground">{c()}</span>
+							</Stack>
+						)}
+					</Index>
+				</Stack>
+			</Stack>
+		</div>
+	),
+};
+
+/** No name + auto → neutral (`data-color="none"`). */
+export const NoNameAutoNeutral: Story = {
+	args: {
+		color: "auto",
+	},
+};
+
+export const ColorNoneNeutral: Story = {
+	args: {
+		name: "Ignored",
+		color: "none",
+	},
+};
+
+/** Strong fallback color should not show once the photo has loaded. */
+export const ImageOverridesColoredFallback: Story = {
+	args: {
+		name: "Jamie Cook",
+		color: "pink",
+		src: "https://i.pravatar.cc/300",
+	},
+};
+
+export const BrokenImageUsesFallback: Story = {
+	args: {
+		name: "Sam Error",
+		color: "teal",
+		src: "https://invalid.invalid/not-a-real-image.png",
+	},
 };

--- a/packages/solid/src/components/avatar/Avatar.tsx
+++ b/packages/solid/src/components/avatar/Avatar.tsx
@@ -1,68 +1,38 @@
-import { Avatar as ArkAvatar, useAvatarContext } from "@ark-ui/solid/avatar";
+import { Avatar as ArkAvatar } from "@ark-ui/solid/avatar";
 import type { AvatarProps as CoreAvatarProps } from "@temporal-ui/core/avatar";
+import { resolveAvatarDataColor } from "@temporal-ui/core/utils/avatar-variant";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { getInitials } from "@temporal-ui/core/utils/string";
 import { UserIcon } from "lucide-solid";
-import { createEffect, Show, splitProps } from "solid-js";
+import { splitProps } from "solid-js";
 
 export interface AvatarProps extends CoreAvatarProps {}
 
 /**
- * Zag's avatar machine runs `checkImageStatus` on enter before the `<img>` exists in the DOM, so
- * `getImageEl` is null and already-decoded images never emit `img.loaded`. Sync once the image
- * node is mounted (and when `src` changes) via the public machine API.
+ * Avatar shows a photo when `src` loads successfully; otherwise it shows initials from `name`, or a
+ * default user icon when initials are empty. When `color` is `"auto"` (default), the fallback
+ * background is a deterministic accent derived from `name` (hash); omit `name`, use only
+ * whitespace, or set `color` to `"none"` for the neutral muted fallback. Accent styles apply only
+ * to the fallback layer — they do not show behind a loaded image.
  */
-function AvatarImageWithStatusSync(props: {
-	src: string | undefined;
-	alt: string | undefined;
-	"data-testid": string | undefined;
-}) {
-	let imgEl: HTMLImageElement | undefined;
-	const avatar = useAvatarContext();
-
-	const syncFromElement = () => {
-		const img = imgEl;
-		if (!img) return;
-		if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
-			avatar().setLoaded();
-		} else if (img.complete) {
-			avatar().setError();
-		}
-	};
-
-	createEffect(() => {
-		void props.src;
-		queueMicrotask(syncFromElement);
-	});
-
-	return (
-		<ArkAvatar.Image
-			ref={(el) => {
-				imgEl = el ?? undefined;
-				queueMicrotask(syncFromElement);
-			}}
-			src={props.src}
-			alt={props.alt}
-			data-testid={props["data-testid"]}
-		/>
-	);
-}
-
 export const Avatar = (_props: AvatarProps & ArkAvatar.RootProps) => {
-	const [props, rootProps] = splitProps(_props, ["name", "src", "size", "className", "class", "testId"]);
+	const [props, rootProps] = splitProps(_props, ["name", "src", "size", "color", "className", "class", "testId"]);
 	const baseClass = ["avatar", props.size !== "md" ? props.size : ""].filter(Boolean).join("-");
 	return (
-		<ArkAvatar.Root class={cx(baseClass, props.className, props.class)} {...rootProps} data-testid={props.testId}>
-			<ArkAvatar.Fallback data-testid={props.testId ? `${props.testId}--fallback` : undefined}>
-				<Show when={props.name} fallback={<UserIcon />}>
-					{getInitials(props.name)}
-				</Show>
-			</ArkAvatar.Fallback>
-			<AvatarImageWithStatusSync
+		<ArkAvatar.Root
+			class={cx(baseClass, props.className, props.class)}
+			data-testid={props.testId}
+			data-color={resolveAvatarDataColor(props.name, props.color ?? "auto")}
+			{...rootProps}
+		>
+			<ArkAvatar.Image
 				src={props.src}
 				alt={props.name}
 				data-testid={props.testId ? `${props.testId}--image` : undefined}
 			/>
+			<ArkAvatar.Fallback data-testid={props.testId ? `${props.testId}--fallback` : undefined}>
+				{getInitials(props.name ?? "") || <UserIcon />}
+			</ArkAvatar.Fallback>
 		</ArkAvatar.Root>
 	);
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements TPX-508: deterministic accent backgrounds for `Avatar` when no image is shown, with full light/dark token mapping and consumer overrides via `data-color` on the root.

## Changes

- **Theme (`@theme`)**: twelve named variants with `--avatar-color-{name}-{bg|fg}-{light|dark}` using Tailwind `var(--color-*-*)` references (yellow uses slightly stronger light bg for contrast).
- **Core**: `getAvatarVariant`, `resolveAvatarDataColor`, `AVATAR_COLOR_VARIANTS`; extended `AvatarProps` with optional `color` (`auto` default behavior documented in JSDoc).
- **CSS**: `--avatar-bg` / `--avatar-fg` set on `.avatar[data-color=…]`; fallback consumes them; image/fallback absolutely positioned so colored fallback does not sit beside the image; `.dark .avatar[…]` for dark scheme.
- **React / Solid**: Ark `Root` → `Image` → `Fallback`; `data-color` on root; removed Solid image status-sync workaround.
- **Stories**: ColorVariants (explicit + auto), DarkMode, edge cases (no name, `none`, image present, broken URL).
- **Tests**: core hash tests; React/Solid integration for `data-color`, explicit override, hidden fallback when image complete.
- **Changeset**: patch for core, react, solid.

## Verification

- `bun run build`, `bun run typecheck`, `bun run lint`
- `bun run test` (all packages)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-508](https://linear.app/temporal1/issue/TPX-508/add-colored-default-avatars-when-no-source-is-provided)

<div><a href="https://cursor.com/agents/bc-4a9db88c-0db1-4c9e-a5e7-c6eb6ed6b6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a9db88c-0db1-4c9e-a5e7-c6eb6ed6b6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

