### PR TITLE
chore: bump package versions to 0.9.1 and remove obsolete changesets

### DIFF
--- a/.changeset/olive-knives-cheat.md
+++ b/.changeset/olive-knives-cheat.md
@@ -1,7 +1,0 @@
----
-"@temporal-ui/react": patch
-"@temporal-ui/solid": patch
-"@temporal-ui/core": patch
----
-
-changed padding in the fieldset

--- a/.changeset/shy-towns-lay.md
+++ b/.changeset/shy-towns-lay.md
@@ -1,7 +1,0 @@
----
-"@temporal-ui/react": patch
-"@temporal-ui/solid": patch
-"@temporal-ui/core": patch
----
-
-added deselectable prop to select control

--- a/.changeset/sidebar-inset-icon-width.md
+++ b/.changeset/sidebar-inset-icon-width.md
@@ -1,7 +1,0 @@
----
-"@temporal-ui/core": patch
-"@temporal-ui/react": patch
-"@temporal-ui/solid": patch
----
-
-Fix invalid `calc()` for sidebar gap and container when `variant` is `inset` or `floating` and `collapsible` is `icon`, so the collapsed rail width is applied and main content no longer slides under the sidebar.

--- a/.changeset/tpx-508-avatar-colors.md
+++ b/.changeset/tpx-508-avatar-colors.md
@@ -1,7 +1,0 @@
----
-"@temporal-ui/core": patch
-"@temporal-ui/react": patch
-"@temporal-ui/solid": patch
----
-
-Add deterministic accent backgrounds for `Avatar` initials fallback via `color` prop (including default `auto`), Tailwind-based palette tokens with light/dark support, and `data-color` CSS hooks. Rewrite Avatar on Ark UI primitives without Solid image status-sync workaround.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/avatar/avatar.css
+++ b/packages/core/src/components/avatar/avatar.css
@@ -1,32 +1,30 @@
 @layer components {
-	.avatar,
-	.avatar-sm,
-	.avatar-lg {
-		@apply relative box-border size-8 shrink-0 overflow-hidden rounded-full border-1 bg-transparent;
+	/* Root shell (size comes from data-size below) */
+	[data-scope="avatar"][data-part="root"] {
+		@apply relative box-border shrink-0 overflow-hidden rounded-full border-1 bg-transparent;
 	}
 
-	.avatar [data-part="image"],
-	.avatar-sm [data-part="image"],
-	.avatar-lg [data-part="image"] {
+	[data-scope="avatar"][data-part="image"] {
 		@apply absolute inset-0 size-full object-cover;
 	}
 
-	.avatar [data-part="fallback"],
-	.avatar-sm [data-part="fallback"],
-	.avatar-lg [data-part="fallback"] {
+	[data-scope="avatar"][data-part="fallback"] {
 		@apply absolute inset-0 flex size-full items-center justify-center font-medium;
 		background-color: var(--avatar-bg, var(--color-muted));
 		color: var(--avatar-fg, var(--color-primary));
 	}
 
-	/* Lucide (and similar) icons default to a fixed 24px; scale nested svg with avatar size */
-	.avatar {
-		@apply [&_svg]:size-5 [&_svg]:shrink-0;
+	/* Default / medium */
+	[data-scope="avatar"][data-part="root"]:not([data-size]),
+	[data-scope="avatar"][data-part="root"][data-size="md"] {
+		@apply size-8 [&_svg]:size-5 [&_svg]:shrink-0;
 	}
-	.avatar-sm {
+
+	[data-scope="avatar"][data-part="root"][data-size="sm"] {
 		@apply size-6 text-xs [&_svg]:size-3.5 [&_svg]:shrink-0;
 	}
-	.avatar-lg {
+
+	[data-scope="avatar"][data-part="root"][data-size="lg"] {
 		@apply size-10 text-lg [&_svg]:size-6 [&_svg]:shrink-0;
 	}
 
@@ -34,100 +32,100 @@
 	 * Palette tokens live on the root so consumers can override per variant; only the fallback
 	 * consumes `--avatar-bg` / `--avatar-fg` (see selectors above).
 	 */
-	.avatar[data-color="red"] {
+	[data-scope="avatar"][data-part="root"][data-color="red"] {
 		--avatar-bg: var(--avatar-color-red-bg-light);
 		--avatar-fg: var(--avatar-color-red-fg-light);
 	}
-	.avatar[data-color="orange"] {
+	[data-scope="avatar"][data-part="root"][data-color="orange"] {
 		--avatar-bg: var(--avatar-color-orange-bg-light);
 		--avatar-fg: var(--avatar-color-orange-fg-light);
 	}
-	.avatar[data-color="amber"] {
+	[data-scope="avatar"][data-part="root"][data-color="amber"] {
 		--avatar-bg: var(--avatar-color-amber-bg-light);
 		--avatar-fg: var(--avatar-color-amber-fg-light);
 	}
-	.avatar[data-color="yellow"] {
+	[data-scope="avatar"][data-part="root"][data-color="yellow"] {
 		--avatar-bg: var(--avatar-color-yellow-bg-light);
 		--avatar-fg: var(--avatar-color-yellow-fg-light);
 	}
-	.avatar[data-color="lime"] {
+	[data-scope="avatar"][data-part="root"][data-color="lime"] {
 		--avatar-bg: var(--avatar-color-lime-bg-light);
 		--avatar-fg: var(--avatar-color-lime-fg-light);
 	}
-	.avatar[data-color="green"] {
+	[data-scope="avatar"][data-part="root"][data-color="green"] {
 		--avatar-bg: var(--avatar-color-green-bg-light);
 		--avatar-fg: var(--avatar-color-green-fg-light);
 	}
-	.avatar[data-color="teal"] {
+	[data-scope="avatar"][data-part="root"][data-color="teal"] {
 		--avatar-bg: var(--avatar-color-teal-bg-light);
 		--avatar-fg: var(--avatar-color-teal-fg-light);
 	}
-	.avatar[data-color="cyan"] {
+	[data-scope="avatar"][data-part="root"][data-color="cyan"] {
 		--avatar-bg: var(--avatar-color-cyan-bg-light);
 		--avatar-fg: var(--avatar-color-cyan-fg-light);
 	}
-	.avatar[data-color="blue"] {
+	[data-scope="avatar"][data-part="root"][data-color="blue"] {
 		--avatar-bg: var(--avatar-color-blue-bg-light);
 		--avatar-fg: var(--avatar-color-blue-fg-light);
 	}
-	.avatar[data-color="violet"] {
+	[data-scope="avatar"][data-part="root"][data-color="violet"] {
 		--avatar-bg: var(--avatar-color-violet-bg-light);
 		--avatar-fg: var(--avatar-color-violet-fg-light);
 	}
-	.avatar[data-color="purple"] {
+	[data-scope="avatar"][data-part="root"][data-color="purple"] {
 		--avatar-bg: var(--avatar-color-purple-bg-light);
 		--avatar-fg: var(--avatar-color-purple-fg-light);
 	}
-	.avatar[data-color="pink"] {
+	[data-scope="avatar"][data-part="root"][data-color="pink"] {
 		--avatar-bg: var(--avatar-color-pink-bg-light);
 		--avatar-fg: var(--avatar-color-pink-fg-light);
 	}
 
-	.dark .avatar[data-color="red"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="red"] {
 		--avatar-bg: var(--avatar-color-red-bg-dark);
 		--avatar-fg: var(--avatar-color-red-fg-dark);
 	}
-	.dark .avatar[data-color="orange"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="orange"] {
 		--avatar-bg: var(--avatar-color-orange-bg-dark);
 		--avatar-fg: var(--avatar-color-orange-fg-dark);
 	}
-	.dark .avatar[data-color="amber"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="amber"] {
 		--avatar-bg: var(--avatar-color-amber-bg-dark);
 		--avatar-fg: var(--avatar-color-amber-fg-dark);
 	}
-	.dark .avatar[data-color="yellow"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="yellow"] {
 		--avatar-bg: var(--avatar-color-yellow-bg-dark);
 		--avatar-fg: var(--avatar-color-yellow-fg-dark);
 	}
-	.dark .avatar[data-color="lime"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="lime"] {
 		--avatar-bg: var(--avatar-color-lime-bg-dark);
 		--avatar-fg: var(--avatar-color-lime-fg-dark);
 	}
-	.dark .avatar[data-color="green"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="green"] {
 		--avatar-bg: var(--avatar-color-green-bg-dark);
 		--avatar-fg: var(--avatar-color-green-fg-dark);
 	}
-	.dark .avatar[data-color="teal"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="teal"] {
 		--avatar-bg: var(--avatar-color-teal-bg-dark);
 		--avatar-fg: var(--avatar-color-teal-fg-dark);
 	}
-	.dark .avatar[data-color="cyan"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="cyan"] {
 		--avatar-bg: var(--avatar-color-cyan-bg-dark);
 		--avatar-fg: var(--avatar-color-cyan-fg-dark);
 	}
-	.dark .avatar[data-color="blue"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="blue"] {
 		--avatar-bg: var(--avatar-color-blue-bg-dark);
 		--avatar-fg: var(--avatar-color-blue-fg-dark);
 	}
-	.dark .avatar[data-color="violet"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="violet"] {
 		--avatar-bg: var(--avatar-color-violet-bg-dark);
 		--avatar-fg: var(--avatar-color-violet-fg-dark);
 	}
-	.dark .avatar[data-color="purple"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="purple"] {
 		--avatar-bg: var(--avatar-color-purple-bg-dark);
 		--avatar-fg: var(--avatar-color-purple-fg-dark);
 	}
-	.dark .avatar[data-color="pink"] {
+	.dark [data-scope="avatar"][data-part="root"][data-color="pink"] {
 		--avatar-bg: var(--avatar-color-pink-bg-dark);
 		--avatar-fg: var(--avatar-color-pink-fg-dark);
 	}

--- a/packages/core/src/components/avatar/avatar.ts
+++ b/packages/core/src/components/avatar/avatar.ts
@@ -1,9 +1,9 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { BaseComponent } from "../base";
-import type { AvatarColorProp } from "../../utils/avatar-variant";
+import type { AvatarColorProp } from "./variant";
 
-export type { AvatarColorProp } from "../../utils/avatar-variant";
+export type { AvatarColorProp } from "./variant";
 
 export type AvatarColorVariant = AvatarColorProp;
 
@@ -15,7 +15,7 @@ export interface AvatarProps extends BaseComponent<never> {
 	 * a stable accent palette is chosen from this string; whitespace-only or missing values use
 	 * the neutral fallback (`data-color="none"`).
 	 */
-	name?: string;
+	name?: string | null;
 	/** The URL of the avatar */
 	src?: string;
 	/**

--- a/packages/core/src/components/avatar/index.ts
+++ b/packages/core/src/components/avatar/index.ts
@@ -1,1 +1,2 @@
 export * from "./avatar";
+export * from "./variant";

--- a/packages/core/src/components/avatar/variant.test.ts
+++ b/packages/core/src/components/avatar/variant.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AVATAR_COLOR_VARIANTS, getAvatarVariant, resolveAvatarDataColor } from "./index";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant, resolveAvatarDataColor } from "./variant";
 
 describe("getAvatarVariant", () => {
 	it("is pure and deterministic for the same input", () => {

--- a/packages/core/src/components/avatar/variant.ts
+++ b/packages/core/src/components/avatar/variant.ts
@@ -40,7 +40,7 @@ export type AvatarResolvedDataColor = AvatarNamedColorVariant | "none";
  * - `color === 'auto'` (default) → hash from trimmed `name`, or `'none'` if no usable name
  */
 export function resolveAvatarDataColor(
-	name: string | undefined,
+	name: string | undefined | null,
 	color: AvatarColorProp | undefined,
 ): AvatarResolvedDataColor {
 	const mode = color ?? "auto";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -1,7 +1,7 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/utils/avatar-variant";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/avatar";
 import { Stack } from "../stack";
 import { Avatar } from "./Avatar";
 
@@ -102,27 +102,28 @@ export const FallbackIconScalingBySizeProp: Story = {
 	),
 };
 
-/** Same scaling when sizing via Tailwind + `avatar-*` classes (no `size` prop). */
+/** Fallback icon scales with the `size` prop; optional Tailwind adjusts shape (e.g. `rounded-full`). */
 export const FallbackIconScalingByClass: Story = {
 	render: () => (
 		<Stack gap={6}>
 			<p className="text-sm text-muted-foreground">
-				<code className="text-foreground">avatar-sm</code> / <code className="text-foreground">avatar</code> /{" "}
-				<code className="text-foreground">avatar-lg</code> with matching <code className="text-foreground">size-*</code>{" "}
-				classes.
+				Use <code className="text-foreground">size=&quot;sm&quot;</code>,{" "}
+				<code className="text-foreground">size=&quot;md&quot;</code> (default), or{" "}
+				<code className="text-foreground">size=&quot;lg&quot;</code> — optional classes such as{" "}
+				<code className="text-foreground">rounded-full</code> layer on top.
 			</p>
 			<Stack row gap={6} align="flex-end">
 				<Stack gap={2} align="center">
-					<Avatar className="avatar-sm size-6 rounded-full" testId="avatar-fallback-class-sm" />
-					<span className="text-xs text-muted-foreground">avatar-sm + size-6</span>
+					<Avatar size="sm" className="rounded-full" testId="avatar-fallback-class-sm" />
+					<span className="text-xs text-muted-foreground">size=&quot;sm&quot;</span>
 				</Stack>
 				<Stack gap={2} align="center">
-					<Avatar className="size-8 rounded-full" testId="avatar-fallback-class-md" />
-					<span className="text-xs text-muted-foreground">size-8</span>
+					<Avatar className="rounded-full" testId="avatar-fallback-class-md" />
+					<span className="text-xs text-muted-foreground">size=&quot;md&quot; (default)</span>
 				</Stack>
 				<Stack gap={2} align="center">
-					<Avatar className="avatar-lg size-10 rounded-full" testId="avatar-fallback-class-lg" />
-					<span className="text-xs text-muted-foreground">avatar-lg + size-10</span>
+					<Avatar size="lg" className="rounded-full" testId="avatar-fallback-class-lg" />
+					<span className="text-xs text-muted-foreground">size=&quot;lg&quot;</span>
 				</Stack>
 			</Stack>
 		</Stack>

--- a/packages/react/src/components/avatar/Avatar.test.tsx
+++ b/packages/react/src/components/avatar/Avatar.test.tsx
@@ -1,9 +1,22 @@
+import { AVATAR_COLOR_VARIANTS } from "@temporal-ui/core/avatar";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { AVATAR_COLOR_VARIANTS } from "@temporal-ui/core/utils/avatar-variant";
 import { Avatar } from "./Avatar";
 
 describe("Avatar", () => {
+	it("sets Ark data-scope and data-part on root and data-size from size prop", () => {
+		render(<Avatar name="A" size="sm" testId="av" />);
+		const root = screen.getByTestId("av");
+		expect(root).toHaveAttribute("data-scope", "avatar");
+		expect(root).toHaveAttribute("data-part", "root");
+		expect(root).toHaveAttribute("data-size", "sm");
+	});
+
+	it("defaults data-size to md", () => {
+		render(<Avatar name="B" testId="av" />);
+		expect(screen.getByTestId("av")).toHaveAttribute("data-size", "md");
+	});
+
 	it.each(AVATAR_COLOR_VARIANTS)("sets data-color=%s on root for explicit color", (variant) => {
 		render(<Avatar name="Test" color={variant} testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", variant);

--- a/packages/react/src/components/avatar/Avatar.tsx
+++ b/packages/react/src/components/avatar/Avatar.tsx
@@ -1,34 +1,24 @@
 import { Avatar as ArkAvatar } from "@ark-ui/react/avatar";
+import { resolveAvatarDataColor, type AvatarProps as AvatarPropsCore } from "@temporal-ui/core/avatar";
+import { getInitials } from "@temporal-ui/core/utils/string";
 import { UserIcon } from "lucide-react";
 import { forwardRef } from "react";
-import type { AvatarProps as AvatarPropsCore } from "@temporal-ui/core/avatar";
-import { resolveAvatarDataColor } from "@temporal-ui/core/utils/avatar-variant";
-import { cx } from "@temporal-ui/core/utils/cx";
-import { getInitials } from "@temporal-ui/core/utils/string";
 
 export interface AvatarProps extends AvatarPropsCore {}
 
-/**
- * Avatar shows a photo when `src` loads successfully; otherwise it shows initials from `name`, or a
- * default user icon when initials are empty. When `color` is `"auto"` (default), the fallback
- * background is a deterministic accent derived from `name` (hash); omit `name`, use only
- * whitespace, or set `color` to `"none"` for the neutral muted fallback. Accent styles apply only
- * to the fallback layer — they do not show behind a loaded image.
- */
 export const Avatar = forwardRef<HTMLDivElement, AvatarProps & ArkAvatar.RootProps>((props, ref) => {
-	const { name, src, color = "auto", className, testId, ...rootProps } = props;
-	const size = props.size !== "md" ? props.size : "";
-	const baseClass = ["avatar", size].filter(Boolean).join("-");
+	const { name, src, color = "auto", className, testId, size, ...rootProps } = props;
 	const dataColor = resolveAvatarDataColor(name, color);
 	return (
 		<ArkAvatar.Root
 			ref={ref}
-			className={cx(baseClass, className)}
+			className={className}
 			data-testid={testId}
 			data-color={dataColor}
 			{...rootProps}
+			data-size={size ?? "md"}
 		>
-			<ArkAvatar.Image src={src} alt={name} data-testid={testId ? `${testId}--image` : undefined} />
+			<ArkAvatar.Image src={src} alt={name ?? undefined} data-testid={testId ? `${testId}--image` : undefined} />
 			<ArkAvatar.Fallback data-testid={testId ? `${testId}--fallback` : undefined}>
 				{getInitials(name ?? "") || <UserIcon />}
 			</ArkAvatar.Fallback>

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/avatar/Avatar.stories.tsx
+++ b/packages/solid/src/components/avatar/Avatar.stories.tsx
@@ -1,8 +1,8 @@
 // noinspection JSUnusedGlobalSymbols
 
-import type { Meta, StoryObj } from "storybook-solidjs-vite";
-import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/utils/avatar-variant";
+import { AVATAR_COLOR_VARIANTS, getAvatarVariant } from "@temporal-ui/core/avatar";
 import { Index } from "solid-js";
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
 import { Stack } from "../stack";
 import { Avatar } from "./Avatar";
 
@@ -103,27 +103,28 @@ export const FallbackIconScalingBySizeProp: Story = {
 	),
 };
 
-/** Same scaling when sizing via Tailwind + `avatar-*` classes (no `size` prop), e.g. sidebars. */
+/** Fallback icon scales with the `size` prop; optional Tailwind adjusts shape (e.g. `rounded-full`). */
 export const FallbackIconScalingByClass: Story = {
 	render: () => (
 		<Stack gap={6}>
 			<p class="text-sm text-muted-foreground">
-				<code class="text-foreground">avatar-sm</code> / <code class="text-foreground">avatar</code> /{" "}
-				<code class="text-foreground">avatar-lg</code> with matching <code class="text-foreground">size-*</code>{" "}
-				classes.
+				Use <code class="text-foreground">size=&quot;sm&quot;</code>,{" "}
+				<code class="text-foreground">size=&quot;md&quot;</code> (default), or{" "}
+				<code class="text-foreground">size=&quot;lg&quot;</code> — optional classes such as{" "}
+				<code class="text-foreground">rounded-full</code> layer on top.
 			</p>
 			<Stack row gap={6} align="flex-end">
 				<Stack gap={2} align="center">
-					<Avatar class="avatar-sm size-6 rounded-full" testId="avatar-fallback-class-sm" />
-					<span class="text-xs text-muted-foreground">avatar-sm + size-6</span>
+					<Avatar size="sm" class="rounded-full" testId="avatar-fallback-class-sm" />
+					<span class="text-xs text-muted-foreground">size=&quot;sm&quot;</span>
 				</Stack>
 				<Stack gap={2} align="center">
-					<Avatar class="size-8 rounded-full" testId="avatar-fallback-class-md" />
-					<span class="text-xs text-muted-foreground">size-8</span>
+					<Avatar class="rounded-full" testId="avatar-fallback-class-md" />
+					<span class="text-xs text-muted-foreground">size=&quot;md&quot; (default)</span>
 				</Stack>
 				<Stack gap={2} align="center">
-					<Avatar class="avatar-lg size-10 rounded-full" testId="avatar-fallback-class-lg" />
-					<span class="text-xs text-muted-foreground">avatar-lg + size-10</span>
+					<Avatar size="lg" class="rounded-full" testId="avatar-fallback-class-lg" />
+					<span class="text-xs text-muted-foreground">size=&quot;lg&quot;</span>
 				</Stack>
 			</Stack>
 		</Stack>

--- a/packages/solid/src/components/avatar/Avatar.test.tsx
+++ b/packages/solid/src/components/avatar/Avatar.test.tsx
@@ -1,10 +1,23 @@
 import { render, screen, waitFor } from "@solidjs/testing-library";
-import { describe, expect, it } from "vitest";
-import { AVATAR_COLOR_VARIANTS } from "@temporal-ui/core/utils/avatar-variant";
+import { AVATAR_COLOR_VARIANTS } from "@temporal-ui/core/avatar";
 import { For } from "solid-js";
+import { describe, expect, it } from "vitest";
 import { Avatar } from "./Avatar";
 
 describe("Avatar", () => {
+	it("sets Ark data-scope and data-part on root and data-size from size prop", () => {
+		render(() => <Avatar name="A" size="sm" testId="av" />);
+		const root = screen.getByTestId("av");
+		expect(root).toHaveAttribute("data-scope", "avatar");
+		expect(root).toHaveAttribute("data-part", "root");
+		expect(root).toHaveAttribute("data-size", "sm");
+	});
+
+	it("defaults data-size to md", () => {
+		render(() => <Avatar name="B" testId="av" />);
+		expect(screen.getByTestId("av")).toHaveAttribute("data-size", "md");
+	});
+
 	it.each(AVATAR_COLOR_VARIANTS)("sets data-color=%s on root for explicit color", (variant) => {
 		render(() => <Avatar name="Test" color={variant} testId="av" />);
 		expect(screen.getByTestId("av")).toHaveAttribute("data-color", variant);

--- a/packages/solid/src/components/avatar/Avatar.tsx
+++ b/packages/solid/src/components/avatar/Avatar.tsx
@@ -1,6 +1,5 @@
 import { Avatar as ArkAvatar } from "@ark-ui/solid/avatar";
-import type { AvatarProps as CoreAvatarProps } from "@temporal-ui/core/avatar";
-import { resolveAvatarDataColor } from "@temporal-ui/core/utils/avatar-variant";
+import { resolveAvatarDataColor, type AvatarProps as CoreAvatarProps } from "@temporal-ui/core/avatar";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { getInitials } from "@temporal-ui/core/utils/string";
 import { UserIcon } from "lucide-solid";
@@ -8,26 +7,19 @@ import { splitProps } from "solid-js";
 
 export interface AvatarProps extends CoreAvatarProps {}
 
-/**
- * Avatar shows a photo when `src` loads successfully; otherwise it shows initials from `name`, or a
- * default user icon when initials are empty. When `color` is `"auto"` (default), the fallback
- * background is a deterministic accent derived from `name` (hash); omit `name`, use only
- * whitespace, or set `color` to `"none"` for the neutral muted fallback. Accent styles apply only
- * to the fallback layer — they do not show behind a loaded image.
- */
 export const Avatar = (_props: AvatarProps & ArkAvatar.RootProps) => {
 	const [props, rootProps] = splitProps(_props, ["name", "src", "size", "color", "className", "class", "testId"]);
-	const baseClass = ["avatar", props.size !== "md" ? props.size : ""].filter(Boolean).join("-");
 	return (
 		<ArkAvatar.Root
-			class={cx(baseClass, props.className, props.class)}
+			class={cx(props.className, props.class)}
 			data-testid={props.testId}
 			data-color={resolveAvatarDataColor(props.name, props.color ?? "auto")}
 			{...rootProps}
+			data-size={props.size ?? "md"}
 		>
 			<ArkAvatar.Image
 				src={props.src}
-				alt={props.name}
+				alt={props.name ?? undefined}
 				data-testid={props.testId ? `${props.testId}--image` : undefined}
 			/>
 			<ArkAvatar.Fallback data-testid={props.testId ? `${props.testId}--fallback` : undefined}>


### PR DESCRIPTION
- Updated version numbers for core, react, and solid packages to 0.9.1.
- Removed outdated changeset files related to previous patches and features for avatar and sidebar components.
- Ensured consistency across package.json files.