### PR TITLE
feat(sidebar): add flush prop for collapsed icon menu items (TPX-626)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/sidebar/sidebar.css
+++ b/packages/core/src/components/sidebar/sidebar.css
@@ -131,6 +131,19 @@
 			&[data-size="lg"] {
 				@apply h-12 text-sm group-data-[collapsible=icon]:p-0!;
 			}
+
+			&[data-flush] {
+				@apply h-auto min-h-8;
+				@apply group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:gap-0! group-data-[collapsible=icon]:justify-center;
+			}
+
+			&[data-flush] [data-scope="avatar"][data-part="root"] {
+				@apply group-data-[collapsible=icon]:size-full!;
+			}
+
+			&[data-flush] > :first-child {
+				@apply group-data-[collapsible=icon]:size-full group-data-[collapsible=icon]:shrink-0;
+			}
 		}
 
 		&[data-slot="menu-action"] {

--- a/packages/core/src/components/sidebar/sidebar.ts
+++ b/packages/core/src/components/sidebar/sidebar.ts
@@ -29,10 +29,14 @@ export interface SidebarMenuButtonProps {
 	isActive?: boolean;
 	variant?: "default" | "outline";
 	size?: "default" | "sm" | "lg";
+	/** When true, collapsed icon mode removes padding so slot content (e.g. avatars) can fill the 32×32 area. */
+	flush?: boolean;
 }
 
 export interface SidebarMenuLinkProps {
 	isActive?: boolean;
+	/** When true, collapsed icon mode removes padding so slot content (e.g. avatars) can fill the 32×32 area. */
+	flush?: boolean;
 }
 
 export interface SidebarMenuSubButtonProps {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/sidebar/Sidebar.stories.tsx
@@ -1,17 +1,27 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Home } from "lucide-react";
+import { Avatar } from "../avatar";
+import { Box } from "../box";
 import { NavMain } from "./examples/NavMain";
 import { NavProjects } from "./examples/NavProjects";
 import { NavUser } from "./examples/NavUser";
 import { TeamSwitcher } from "./examples/TeamSwitcher";
 import { Sidebar } from "./Sidebar";
-import { SidebarContent, SidebarFooter, SidebarHeader, SidebarInset } from "./SidebarComponent";
+import {
+	SidebarContent,
+	SidebarFooter,
+	SidebarGroup,
+	SidebarGroupLabel,
+	SidebarHeader,
+	SidebarInset,
+} from "./SidebarComponent";
+import { SidebarMenu, SidebarMenuItem, SidebarMenuLink } from "./SidebarMenu";
 import { SidebarProvider } from "./SidebarProvider";
 import { SidebarRail } from "./SidebarRail";
 import { SidebarTrigger } from "./SidebarTrigger";
 import { data } from "./examples/data";
-import { Box } from "../box";
 
 const meta = {
 	title: "React/Sidebar",
@@ -91,6 +101,60 @@ export const Inset: Story = {
 				<SidebarInset>
 					<SidebarTrigger />
 					{args.children}
+				</SidebarInset>
+			</SidebarProvider>
+		</Box>
+	),
+};
+
+/**
+ * Collapsed icon mode comparison for menu links.
+ *
+ * - Default rows keep `p-2` padding for small lucide icons.
+ * - Use `flush` when the collapsed representation should fill the 32×32 slot (avatars, large icons).
+ * - Do not use `size="lg"` just for collapsed padding — use `flush` instead.
+ */
+export const FlushCollapsed: Story = {
+	args: {
+		side: "left",
+		variant: "sidebar",
+		collapsible: "icon",
+	},
+	render: (args) => (
+		<Box className="">
+			<SidebarProvider className="" defaultOpen={false}>
+				<Sidebar {...args}>
+					<SidebarContent>
+						<SidebarGroup>
+							<SidebarGroupLabel>Collapsed icon mode</SidebarGroupLabel>
+							<SidebarMenu>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#default">
+										<Home />
+										<span>Default icon link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#avatar" flush>
+										<Avatar name="Jane Doe" size="md" />
+										<span>Flush avatar link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#emoji" flush>
+										<span aria-hidden="true" className="text-lg leading-none">
+											🚀
+										</span>
+										<span>Flush emoji link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+							</SidebarMenu>
+						</SidebarGroup>
+					</SidebarContent>
+					<SidebarRail />
+				</Sidebar>
+				<SidebarInset>
+					<SidebarTrigger />
 				</SidebarInset>
 			</SidebarProvider>
 		</Box>

--- a/packages/react/src/components/sidebar/Sidebar.test.tsx
+++ b/packages/react/src/components/sidebar/Sidebar.test.tsx
@@ -220,6 +220,54 @@ describe("SidebarMenu Components", () => {
 		expect(link).toHaveAttribute("href", "/test");
 	});
 
+	it("renders data-flush on menu button and link when flush is true", () => {
+		render(
+			<SidebarProvider>
+				<Sidebar side="left">
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton flush>Flush Button</SidebarMenuButton>
+						</SidebarMenuItem>
+						<SidebarMenuItem>
+							<SidebarMenuLink href="/flush" flush>
+								Flush Link
+							</SidebarMenuLink>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</Sidebar>
+			</SidebarProvider>,
+		);
+
+		const button = screen.getByRole("button", { name: "Flush Button" });
+		const link = screen.getByRole("link", { name: "Flush Link" });
+
+		expect(button).toHaveAttribute("data-flush");
+		expect(link).toHaveAttribute("data-flush");
+	});
+
+	it("omits data-flush when flush is false or unset", () => {
+		render(
+			<SidebarProvider>
+				<Sidebar side="left">
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton>Default Button</SidebarMenuButton>
+						</SidebarMenuItem>
+						<SidebarMenuItem>
+							<SidebarMenuLink href="/default">Default Link</SidebarMenuLink>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</Sidebar>
+			</SidebarProvider>,
+		);
+
+		const button = screen.getByRole("button", { name: "Default Button" });
+		const link = screen.getByRole("link", { name: "Default Link" });
+
+		expect(button).not.toHaveAttribute("data-flush");
+		expect(link).not.toHaveAttribute("data-flush");
+	});
+
 	it("renders sub-menu components correctly", () => {
 		render(
 			<SidebarProvider>

--- a/packages/react/src/components/sidebar/SidebarMenu.tsx
+++ b/packages/react/src/components/sidebar/SidebarMenu.tsx
@@ -27,7 +27,7 @@ export function SidebarMenuItem(props: SidebarMenuItemProps) {
 export type SidebarMenuButtonProps = React.ComponentProps<"button"> & CoreSidebarMenuButtonProps;
 
 export function SidebarMenuButton(props: SidebarMenuButtonProps) {
-	const { variant = "default", size = "default", isActive, ...rest } = props;
+	const { variant = "default", size = "default", isActive, flush, ...rest } = props;
 
 	return (
 		<button
@@ -37,6 +37,7 @@ export function SidebarMenuButton(props: SidebarMenuButtonProps) {
 			data-variant={variant}
 			data-size={size}
 			data-active={isActive}
+			data-flush={flush || undefined}
 		/>
 	);
 }
@@ -44,9 +45,17 @@ export function SidebarMenuButton(props: SidebarMenuButtonProps) {
 export type SidebarMenuLinkProps = React.ComponentProps<"a"> & CoreSidebarMenuLinkProps;
 
 export function SidebarMenuLink(props: SidebarMenuLinkProps) {
-	const { isActive, ...rest } = props;
+	const { isActive, flush, ...rest } = props;
 
-	return <a {...rest} data-component="sidebar" data-slot="menu-link" data-active={isActive} />;
+	return (
+		<a
+			{...rest}
+			data-component="sidebar"
+			data-slot="menu-link"
+			data-active={isActive}
+			data-flush={flush || undefined}
+		/>
+	);
 }
 
 export type SidebarMenuActionProps = React.ComponentProps<"button">;

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/sidebar/Sidebar.stories.tsx
+++ b/packages/solid/src/components/sidebar/Sidebar.stories.tsx
@@ -1,6 +1,8 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { Home } from "lucide-solid";
+import { Avatar } from "../avatar";
 import { Box } from "../box";
 import { data } from "./examples/data";
 import { NavMain } from "./examples/NavMain";
@@ -8,7 +10,15 @@ import { NavProjects } from "./examples/NavProjects";
 import { NavUser } from "./examples/NavUser";
 import { TeamSwitcher } from "./examples/TeamSwitcher";
 import { Sidebar, type SidebarProps } from "./Sidebar";
-import { SidebarContent, SidebarFooter, SidebarHeader, SidebarInset } from "./SidebarComponent";
+import {
+	SidebarContent,
+	SidebarFooter,
+	SidebarGroup,
+	SidebarGroupLabel,
+	SidebarHeader,
+	SidebarInset,
+} from "./SidebarComponent";
+import { SidebarMenu, SidebarMenuItem, SidebarMenuLink } from "./SidebarMenu";
 import { SidebarProvider } from "./SidebarProvider";
 import { SidebarRail } from "./SidebarRail";
 import { SidebarTrigger } from "./SidebarTrigger";
@@ -91,6 +101,60 @@ export const Inset: Story = {
 				<SidebarInset>
 					<SidebarTrigger />
 					{args.children}
+				</SidebarInset>
+			</SidebarProvider>
+		</Box>
+	),
+};
+
+/**
+ * Collapsed icon mode comparison for menu links.
+ *
+ * - Default rows keep `p-2` padding for small lucide icons.
+ * - Use `flush` when the collapsed representation should fill the 32×32 slot (avatars, large icons).
+ * - Do not use `size="lg"` just for collapsed padding — use `flush` instead.
+ */
+export const FlushCollapsed: Story = {
+	args: {
+		side: "left",
+		variant: "sidebar",
+		collapsible: "icon",
+	},
+	render: (args: SidebarProps) => (
+		<Box class="">
+			<SidebarProvider class="" defaultOpen={false}>
+				<Sidebar {...args}>
+					<SidebarContent>
+						<SidebarGroup>
+							<SidebarGroupLabel>Collapsed icon mode</SidebarGroupLabel>
+							<SidebarMenu>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#default">
+										<Home />
+										<span>Default icon link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#avatar" flush>
+										<Avatar name="Jane Doe" size="md" />
+										<span>Flush avatar link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+								<SidebarMenuItem>
+									<SidebarMenuLink href="#emoji" flush>
+										<span aria-hidden="true" class="text-lg leading-none">
+											🚀
+										</span>
+										<span>Flush emoji link</span>
+									</SidebarMenuLink>
+								</SidebarMenuItem>
+							</SidebarMenu>
+						</SidebarGroup>
+					</SidebarContent>
+					<SidebarRail />
+				</Sidebar>
+				<SidebarInset>
+					<SidebarTrigger />
 				</SidebarInset>
 			</SidebarProvider>
 		</Box>

--- a/packages/solid/src/components/sidebar/Sidebar.test.tsx
+++ b/packages/solid/src/components/sidebar/Sidebar.test.tsx
@@ -300,6 +300,54 @@ describe("SidebarMenu Components", () => {
 		expect(link).toHaveAttribute("href", "/test");
 	});
 
+	it("renders data-flush on menu button and link when flush is true", () => {
+		render(() => (
+			<SidebarProvider>
+				<Sidebar side="left">
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton flush>Flush Button</SidebarMenuButton>
+						</SidebarMenuItem>
+						<SidebarMenuItem>
+							<SidebarMenuLink href="/flush" flush>
+								Flush Link
+							</SidebarMenuLink>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</Sidebar>
+			</SidebarProvider>
+		));
+
+		const button = screen.getByRole("button", { name: "Flush Button" });
+		const link = screen.getByRole("link", { name: "Flush Link" });
+
+		expect(button).toHaveAttribute("data-flush");
+		expect(link).toHaveAttribute("data-flush");
+	});
+
+	it("omits data-flush when flush is false or unset", () => {
+		render(() => (
+			<SidebarProvider>
+				<Sidebar side="left">
+					<SidebarMenu>
+						<SidebarMenuItem>
+							<SidebarMenuButton>Default Button</SidebarMenuButton>
+						</SidebarMenuItem>
+						<SidebarMenuItem>
+							<SidebarMenuLink href="/default">Default Link</SidebarMenuLink>
+						</SidebarMenuItem>
+					</SidebarMenu>
+				</Sidebar>
+			</SidebarProvider>
+		));
+
+		const button = screen.getByRole("button", { name: "Default Button" });
+		const link = screen.getByRole("link", { name: "Default Link" });
+
+		expect(button).not.toHaveAttribute("data-flush");
+		expect(link).not.toHaveAttribute("data-flush");
+	});
+
 	it("renders sub-menu components correctly", () => {
 		render(() => (
 			<SidebarProvider>

--- a/packages/solid/src/components/sidebar/SidebarMenu.tsx
+++ b/packages/solid/src/components/sidebar/SidebarMenu.tsx
@@ -34,7 +34,7 @@ export interface SidebarMenuButtonProps extends HTMLProps<"button">, CoreSidebar
 export function SidebarMenuButton(_props: SidebarMenuButtonProps) {
 	const [props, elementProps] = splitProps(
 		mergeProps({ variant: "default", size: "default" }, _props),
-		["variant", "size", "isActive"],
+		["variant", "size", "isActive", "flush"],
 	);
 
 	return (
@@ -45,6 +45,7 @@ export function SidebarMenuButton(_props: SidebarMenuButtonProps) {
 			data-variant={props.variant}
 			data-size={props.size}
 			data-active={props.isActive}
+			data-flush={props.flush || undefined}
 		/>
 	);
 }
@@ -55,7 +56,7 @@ export interface SidebarMenuLinkProps extends HTMLProps<"a">, CoreSidebarMenuLin
 }
 
 export function SidebarMenuLink(_props: SidebarMenuLinkProps) {
-	const [props, elementProps] = splitProps(_props, ["isActive", "component"]);
+	const [props, elementProps] = splitProps(_props, ["isActive", "component", "flush"]);
 
 	return (
 		<ark.a
@@ -63,6 +64,7 @@ export function SidebarMenuLink(_props: SidebarMenuLinkProps) {
 			data-component="sidebar"
 			data-slot="menu-link"
 			data-active={props.isActive}
+			data-flush={props.flush || undefined}
 			asChild={props.component}
 		/>
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an optional `flush` prop to `SidebarMenuButton` and `SidebarMenuLink` so avatars and other full-slot content can fill the 32×32 collapsed icon slot without the default `p-2` inset padding.

Fixes TPX-626.

## Changes

### Core (`@temporal-ui/core`)
- Extended `SidebarMenuButtonProps` and `SidebarMenuLinkProps` with `flush?: boolean`
- Added `[data-flush]` CSS modifier under menu-button/menu-link slots:
  - Collapsed icon mode: `p-0`, `gap-0`, centered content
  - Expanded: `h-auto min-h-8` (compact row, not `h-12` like `size="lg"`)
  - Avatar and first-child sizing rules for full-slot content in collapsed mode

### React & Solid
- `flush` prop split from element props and rendered as `data-flush` when true
- New `FlushCollapsed` Storybook story demonstrating default icon link vs flush avatar/emoji links
- Unit tests verifying `data-flush` presence/absence

## Usage

```tsx
<SidebarMenuLink href="/profile" flush>
  <Avatar name="Jane Doe" size="md" />
  <span>Profile</span>
</SidebarMenuLink>
```

**Note:** Use `flush` for collapsed full-slot content (avatars, large icons). Do not use `size="lg"` just for collapsed padding.

## Testing

- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Sidebar unit tests (React: 13 passed, Solid: 14 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-626](https://linear.app/temprix/issue/TPX-626/add-flush-prop-to-sidebar-menu-items-for-collapsed-icon-mode)

<div><a href="https://cursor.com/agents/bc-2a1ee622-a441-4119-a6b3-983db62e51a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a1ee622-a441-4119-a6b3-983db62e51a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

