### PR TITLE
feat(switch): add Switch component with size variants (TPX-697)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.9.4",
+	"version": "0.10.0",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.9.4",
+	"version": "0.10.0",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/switch/index.ts
+++ b/packages/core/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export type { SwitchClasses, SwitchProps, SwitchSize } from "./switch";

--- a/packages/core/src/components/switch/switch.css
+++ b/packages/core/src/components/switch/switch.css
@@ -1,0 +1,92 @@
+@layer components {
+	[data-scope="switch"][data-part="root"] {
+		@apply flex flex-row items-center cursor-pointer data-disabled:cursor-default data-readonly:cursor-default;
+	}
+
+	[data-scope="switch"][data-part="label"] {
+		@apply transition-all data-disabled:text-muted-foreground;
+	}
+
+	[data-scope="switch"][data-part="control"] {
+		@apply inline-flex shrink-0 items-center rounded-full p-0.5 bg-input dark:bg-input/30 outline-none transition-all;
+		&[data-disabled] {
+			@apply cursor-not-allowed opacity-50;
+		}
+		&[data-invalid] {
+			@apply ring-destructive/20 dark:ring-destructive/40 ring-[3px];
+		}
+		&[data-focus-visible] {
+			@apply ring-ring/50 ring-[3px];
+		}
+		&[data-state="checked"] {
+			@apply bg-primary dark:bg-primary;
+		}
+		&[data-hover]:not([data-readonly]) {
+			&:not([data-state="checked"]) {
+				@apply bg-primary/20 dark:bg-primary/20;
+			}
+			&[data-state="checked"] {
+				@apply bg-primary/80 dark:bg-primary/80;
+			}
+		}
+	}
+
+	[data-scope="switch"][data-part="thumb"] {
+		@apply block rounded-full bg-background shadow-xs transition-transform;
+	}
+
+	/* Small */
+	[data-scope="switch"][data-part="root"][data-size="sm"] {
+		@apply gap-1.5;
+	}
+	[data-scope="switch"][data-part="root"][data-size="sm"] [data-part="label"] {
+		@apply text-xs;
+	}
+	[data-scope="switch"][data-part="root"][data-size="sm"] [data-part="control"] {
+		@apply h-5 w-8;
+	}
+	[data-scope="switch"][data-part="root"][data-size="sm"] [data-part="thumb"] {
+		@apply size-4;
+		&[data-state="checked"] {
+			@apply translate-x-3;
+		}
+	}
+
+	/* Medium (default) */
+	[data-scope="switch"][data-part="root"]:not([data-size]),
+	[data-scope="switch"][data-part="root"][data-size="md"] {
+		@apply gap-2;
+	}
+	[data-scope="switch"][data-part="root"]:not([data-size]) [data-part="label"],
+	[data-scope="switch"][data-part="root"][data-size="md"] [data-part="label"] {
+		@apply text-sm;
+	}
+	[data-scope="switch"][data-part="root"]:not([data-size]) [data-part="control"],
+	[data-scope="switch"][data-part="root"][data-size="md"] [data-part="control"] {
+		@apply h-6 w-10;
+	}
+	[data-scope="switch"][data-part="root"]:not([data-size]) [data-part="thumb"],
+	[data-scope="switch"][data-part="root"][data-size="md"] [data-part="thumb"] {
+		@apply size-5;
+		&[data-state="checked"] {
+			@apply translate-x-4;
+		}
+	}
+
+	/* Large */
+	[data-scope="switch"][data-part="root"][data-size="lg"] {
+		@apply gap-2.5;
+	}
+	[data-scope="switch"][data-part="root"][data-size="lg"] [data-part="label"] {
+		@apply text-base;
+	}
+	[data-scope="switch"][data-part="root"][data-size="lg"] [data-part="control"] {
+		@apply h-7 w-12;
+	}
+	[data-scope="switch"][data-part="root"][data-size="lg"] [data-part="thumb"] {
+		@apply size-6;
+		&[data-state="checked"] {
+			@apply translate-x-5;
+		}
+	}
+}

--- a/packages/core/src/components/switch/switch.ts
+++ b/packages/core/src/components/switch/switch.ts
@@ -1,0 +1,19 @@
+import type { FieldProps } from "../field";
+
+export type SwitchSize = "sm" | "md" | "lg";
+
+export type SwitchClasses = Pick<
+	NonNullable<FieldProps<unknown>["classes"]>,
+	"root" | "label" | "hint" | "error" | "input"
+> & {
+	control?: string;
+	thumb?: string;
+};
+
+export interface SwitchProps<T> extends Omit<FieldProps<T>, "classes"> {
+	size?: SwitchSize;
+	defaultChecked?: boolean;
+	checked?: boolean;
+	onCheckedChange?: (checked: boolean) => void;
+	classes?: SwitchClasses;
+}

--- a/packages/core/src/styles.css
+++ b/packages/core/src/styles.css
@@ -29,6 +29,7 @@
 @import "./components/sidebar/sidebar.css";
 @import "./components/slider/slider.css";
 @import "./components/stack/stack.css";
+@import "./components/switch/switch.css";
 @import "./components/table/table.css";
 @import "./components/tabs/tabs.css";
 @import "./components/text-input/text-input.css";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.9.4",
+	"version": "0.10.0",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/switch/Switch.stories.tsx
+++ b/packages/react/src/components/switch/Switch.stories.tsx
@@ -1,0 +1,77 @@
+// noinspection JSUnusedGlobalSymbols
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { Switch } from "./Switch";
+
+const meta = {
+	title: "React/Switch",
+	component: Switch,
+	tags: ["autodocs"],
+	args: { onCheckedChange: fn() },
+	argTypes: {
+		disabled: {
+			type: "boolean",
+			control: "boolean",
+		},
+		checked: {
+			type: "boolean",
+			control: "boolean",
+		},
+		size: {
+			control: "select",
+			options: ["sm", "md", "lg"],
+		},
+	},
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: "Enable notifications",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		...Default.args,
+		disabled: true,
+	},
+};
+
+export const WithHint: Story = {
+	args: {
+		...Default.args,
+		hint: "Receive email updates about your account activity.",
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		...Default.args,
+		error: "This field is required.",
+	},
+};
+
+export const Checked: Story = {
+	args: {
+		...Default.args,
+		checked: true,
+	},
+};
+
+export const Small: Story = {
+	args: {
+		...Default.args,
+		size: "sm",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		...Default.args,
+		size: "lg",
+	},
+};

--- a/packages/react/src/components/switch/Switch.test.tsx
+++ b/packages/react/src/components/switch/Switch.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Switch } from "./Switch";
+
+describe("Switch", () => {
+	it("should render", () => {
+		render(<Switch label="Enable notifications" />);
+		expect(screen.getByLabelText("Enable notifications")).toBeInTheDocument();
+	});
+
+	it('should be disabled when "disabled" prop is true', () => {
+		render(<Switch label="Enable notifications" disabled />);
+		expect(screen.getByLabelText("Enable notifications")).toBeDisabled();
+	});
+
+	it('should be checked when "checked" prop is true', () => {
+		render(<Switch label="Enable notifications" checked />);
+		expect(screen.getByLabelText("Enable notifications")).toBeChecked();
+	});
+
+	it("wraps in Field and shows hint and error", () => {
+		render(
+			<Switch
+				testId="my-switch"
+				label="Enable notifications"
+				hint="Receive email updates"
+				error="This field is required"
+			/>,
+		);
+		expect(screen.getByText("Receive email updates")).toBeInTheDocument();
+		expect(screen.getByText("This field is required")).toBeInTheDocument();
+		expect(screen.getByTestId("my-switch-field--root")).toBeInTheDocument();
+		expect(screen.getByLabelText("Enable notifications")).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("defaults data-size to md", () => {
+		render(<Switch testId="my-switch" label="Enable notifications" />);
+		expect(screen.getByTestId("my-switch--root")).toHaveAttribute("data-size", "md");
+	});
+
+	it("sets data-size from size prop", () => {
+		render(<Switch testId="my-switch" label="Enable notifications" size="sm" />);
+		expect(screen.getByTestId("my-switch--root")).toHaveAttribute("data-size", "sm");
+	});
+});

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -1,0 +1,66 @@
+import { Switch as ArkSwitch } from "@ark-ui/react/switch";
+import type { SwitchProps as CoreSwitchProps } from "@temporal-ui/core/switch";
+import { testId as testIdFn } from "@temporal-ui/core/utils/string";
+import type React from "react";
+import { forwardRef } from "react";
+import { Field } from "../field";
+
+export interface SwitchProps extends CoreSwitchProps<React.ReactNode> {}
+
+export const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
+	const {
+		label,
+		hint,
+		error,
+		required,
+		readOnly,
+		disabled,
+		classes,
+		size = "md",
+		defaultChecked,
+		checked,
+		onCheckedChange,
+		testId,
+		...rest
+	} = props;
+
+	const tid = testIdFn(testId);
+
+	return (
+		<Field
+			label={undefined}
+			hint={hint}
+			classes={classes}
+			required={required}
+			readOnly={readOnly}
+			error={error}
+			disabled={disabled}
+			testId={tid("-field")}
+		>
+			<ArkSwitch.Root
+				defaultChecked={defaultChecked}
+				checked={checked}
+				onCheckedChange={(details) => onCheckedChange?.(details.checked)}
+				disabled={disabled}
+				readOnly={readOnly}
+				invalid={!!error}
+				required={required}
+				data-size={size}
+				data-testid={tid("--root")}
+			>
+				<ArkSwitch.Control data-testid={tid("--control")} className={classes?.control}>
+					<ArkSwitch.Thumb data-testid={tid("--thumb")} className={classes?.thumb} />
+				</ArkSwitch.Control>
+				<ArkSwitch.Label data-testid={tid("--label")} className={classes?.label}>
+					{label}
+				</ArkSwitch.Label>
+				<ArkSwitch.HiddenInput
+					ref={ref}
+					data-testid={tid("--input")}
+					className={classes?.input}
+					{...rest}
+				/>
+			</ArkSwitch.Root>
+		</Field>
+	);
+});

--- a/packages/react/src/components/switch/index.ts
+++ b/packages/react/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export { Switch, type SwitchProps } from "./Switch";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,12 +24,13 @@ export * from "./components/separator";
 export * from "./components/sidebar";
 export * from "./components/slider";
 export * from "./components/stack";
+export * from "./components/switch";
 export * from "./components/table";
 export * from "./components/tabs";
 export * from "./components/text-input";
-export * from "./components/tooltip";
 export * from "./components/textarea";
 export * from "./components/toggle";
+export * from "./components/tooltip";
 
 // Hooks
 export * from "./hooks/is-mobile";

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.9.4",
+	"version": "0.10.0",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/switch/Switch.stories.tsx
+++ b/packages/solid/src/components/switch/Switch.stories.tsx
@@ -1,0 +1,77 @@
+// noinspection JSUnusedGlobalSymbols
+
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { fn } from "storybook/test";
+import { Switch } from "./Switch";
+
+const meta = {
+	title: "Solid/Switch",
+	component: Switch,
+	tags: ["autodocs"],
+	args: { onCheckedChange: fn() },
+	argTypes: {
+		disabled: {
+			type: "boolean",
+			control: "boolean",
+		},
+		checked: {
+			type: "boolean",
+			control: "boolean",
+		},
+		size: {
+			control: "select",
+			options: ["sm", "md", "lg"],
+		},
+	},
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	args: {
+		label: "Enable notifications",
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		...Default.args,
+		disabled: true,
+	},
+};
+
+export const WithHint: Story = {
+	args: {
+		...Default.args,
+		hint: "Receive email updates about your account activity.",
+	},
+};
+
+export const WithError: Story = {
+	args: {
+		...Default.args,
+		error: "This field is required.",
+	},
+};
+
+export const Checked: Story = {
+	args: {
+		...Default.args,
+		checked: true,
+	},
+};
+
+export const Small: Story = {
+	args: {
+		...Default.args,
+		size: "sm",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		...Default.args,
+		size: "lg",
+	},
+};

--- a/packages/solid/src/components/switch/Switch.test.tsx
+++ b/packages/solid/src/components/switch/Switch.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import { Switch } from "./Switch";
+
+describe("Switch", () => {
+	it("should render", () => {
+		render(() => <Switch label="Enable notifications" />);
+		expect(screen.getByLabelText("Enable notifications")).toBeInTheDocument();
+	});
+
+	it('should be disabled when "disabled" prop is true', () => {
+		render(() => <Switch label="Enable notifications" disabled />);
+		expect(screen.getByLabelText("Enable notifications")).toBeDisabled();
+	});
+
+	it('should be checked when "checked" prop is true', () => {
+		render(() => <Switch label="Enable notifications" checked />);
+		expect(screen.getByLabelText("Enable notifications")).toBeChecked();
+	});
+
+	it("wraps in Field and shows hint and error", () => {
+		render(() => (
+			<Switch
+				testId="my-switch"
+				label="Enable notifications"
+				hint="Receive email updates"
+				error="This field is required"
+			/>
+		));
+		expect(screen.getByText("Receive email updates")).toBeInTheDocument();
+		expect(screen.getByText("This field is required")).toBeInTheDocument();
+		expect(screen.getByTestId("my-switch-field--root")).toBeInTheDocument();
+		expect(screen.getByLabelText("Enable notifications")).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("defaults data-size to md", () => {
+		render(() => <Switch testId="my-switch" label="Enable notifications" />);
+		expect(screen.getByTestId("my-switch--root")).toHaveAttribute("data-size", "md");
+	});
+
+	it("sets data-size from size prop", () => {
+		render(() => <Switch testId="my-switch" label="Enable notifications" size="sm" />);
+		expect(screen.getByTestId("my-switch--root")).toHaveAttribute("data-size", "sm");
+	});
+});

--- a/packages/solid/src/components/switch/Switch.tsx
+++ b/packages/solid/src/components/switch/Switch.tsx
@@ -1,0 +1,55 @@
+import type { HTMLProps } from "@ark-ui/solid";
+import { Switch as ArkSwitch } from "@ark-ui/solid/switch";
+import type { SwitchProps as CoreSwitchProps } from "@temporal-ui/core/switch";
+import { testId } from "@temporal-ui/core/utils/string";
+import type { JSX } from "solid-js";
+import { Show, splitProps } from "solid-js";
+import { Field } from "../field";
+
+export interface SwitchProps
+	extends CoreSwitchProps<JSX.Element>, Omit<HTMLProps<"input">, "checked" | "onInput" | "size"> {}
+
+export function Switch(_props: SwitchProps) {
+	const [fieldProps, rootProps] = splitProps(
+		_props,
+		["label", "hint", "error", "required", "readOnly", "disabled", "classes", "testId", "size"],
+		["defaultChecked", "checked", "onCheckedChange"],
+	);
+
+	const tid = testId(fieldProps.testId);
+
+	return (
+		<Field
+			label={undefined}
+			hint={fieldProps.hint}
+			classes={fieldProps.classes}
+			required={fieldProps.required}
+			readOnly={fieldProps.readOnly}
+			error={fieldProps.error}
+			disabled={fieldProps.disabled}
+			testId={tid("-field")}
+		>
+			<ArkSwitch.Root
+				defaultChecked={rootProps.defaultChecked}
+				checked={rootProps.checked}
+				onCheckedChange={(details) => rootProps.onCheckedChange?.(details.checked)}
+				disabled={fieldProps.disabled}
+				readOnly={fieldProps.readOnly}
+				invalid={!!fieldProps.error}
+				required={fieldProps.required}
+				data-size={fieldProps.size ?? "md"}
+				data-testid={tid("--root")}
+			>
+				<ArkSwitch.Control data-testid={tid("--control")} class={fieldProps.classes?.control}>
+					<ArkSwitch.Thumb data-testid={tid("--thumb")} class={fieldProps.classes?.thumb} />
+				</ArkSwitch.Control>
+				<Show when={fieldProps.label}>
+					<ArkSwitch.Label data-testid={tid("--label")} class={fieldProps.classes?.label}>
+						{fieldProps.label}
+					</ArkSwitch.Label>
+				</Show>
+				<ArkSwitch.HiddenInput data-testid={tid("--input")} class={fieldProps.classes?.input} />
+			</ArkSwitch.Root>
+		</Field>
+	);
+}

--- a/packages/solid/src/components/switch/index.ts
+++ b/packages/solid/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export { Switch, type SwitchProps } from "./Switch";

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -24,12 +24,13 @@ export * from "./components/separator";
 export * from "./components/sidebar";
 export * from "./components/slider";
 export * from "./components/stack";
+export * from "./components/switch";
 export * from "./components/table";
 export * from "./components/tabs";
 export * from "./components/text-input";
 export * from "./components/textarea";
-export * from "./components/tooltip";
 export * from "./components/toggle";
+export * from "./components/tooltip";
 
 // Hooks
 export * from "./hooks/is-mobile";


### PR DESCRIPTION
## Summary

- Add `Switch` component across `@temporal-ui/core`, `@temporal-ui/react`, and `@temporal-ui/solid`, wrapping Ark UI's switch primitive with `Field` integration for hint/error states
- Support `checked` / `defaultChecked` / `onCheckedChange` and a `size` prop (`sm` | `md` | `lg`)
- Bump package versions from `0.9.4` to `0.10.0`

Linear: [TPX-697](https://linear.app/temprix/issue/TPX-697/add-switch-component-ark-ui)

## Test plan

- [x] `bun run build`
- [x] React and Solid Switch unit tests pass
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Preview in Storybook (`bun run react` / `bun run solid`) — React/Switch and Solid/Switch stories


Made with [Cursor](https://cursor.com)