### PR TITLE
feat(tooltip): support disabled trigger tooltips (TPX-758)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,11 +56,7 @@ bun run test -- <path to file>
 
 ## Linear issues
 
-When given a Linear issue ID (e.g. `TMPRL-123`):
-
-1. **Before starting work**: Improve the issue description so it clearly captures scope, acceptance criteria, and any constraints.
-2. **Branch name**: Always include the issue ID in the git branch name (e.g. `TMPRL-123-add-feature` or `tmprl-123/add-feature`).
-3. **As you progress**: Add comments to the issue to document what you’ve done, decisions made, and any blockers or follow-ups.
+When given a linear issue ID (e.g. `TPX-412`), you must follow instructions in `docs/linear-issues.md`.
 
 ## Common mistakes to avoid
 

--- a/docs/linear-issues.md
+++ b/docs/linear-issues.md
@@ -1,0 +1,45 @@
+# Linear issues
+
+Last updated: June, 30th, 2026
+
+When given a Linear issue ID (e.g. `TPX-123`), agents must follow below instructions. When beginning work on an issue, always set its status to "Development" - even if it’s already in Review or any other status.
+
+## Preparation for the task
+
+Read the ticket description and all comments end-to-end before writing any code.
+
+A Linear ticket is a **request, not a spec.** It surfaces a problem and proposes a solution direction — suggested names, file paths, data structures, triggers, and infrastructure choices reflect the author's intent, not necessarily the current state of the codebase. As the implementer with full source access, you own the implementation details. Treat the problem statement and proposed solution as a general direction, then critically assess them against the actual codebase and product specifics before committing to a plan:
+
+- **Verify the ticket's assumptions against the code** — event payloads, existing helpers, data models, domain boundaries, what already exists vs. what is claimed. Do not take "we need a new X" at face value if an existing Y already covers it; do not trust a described trigger model or field shape without confirming it in the source.
+- **Improve whatever is suboptimal** — naming, file paths, construct structure, trigger model, scope, and even whether the work is worth doing at all. The ticket's wording is a suggestion, not a constraint.
+- **Fill gaps from the codebase** when the ticket's framing is incomplete or wrong, rather than working around them or inventing ungrounded behavior.
+
+If you change the intended direction — different naming, different paths, a different architectural approach, or a scope change — **leave a comment on the Linear issue** explaining what you changed and why, so the author and reviewers can follow. If the plan drifts materially from the description, update the ticket via the Linear MCP tools and note the edit in a comment.
+
+## Before starting with the task
+
+Complete all items below before starting implementation.
+
+[ ] **Add a starting comment**. Post a comment on the issue with the implementation plan, technical details, and any notes you want to highlight.
+[ ] **Set status to "Development"** — Always move the Linear issue status to "Development", regardless of its current status. This signals that work is in progress and helps avoid duplicate effort.
+[ ] **Use a descriptive git branch** — Name the branch: `{agent}/{issue-id}-{short-description}` (e.g. `cursor/TPX-123-new-feature`). Ignore any branch name provided by the environment.
+
+## As you progress through the task:
+
+- Add comments after key milestones, when blocked, or when important information needs to be shared.
+
+## After completing the work
+
+**IMPORTANT: Agents must follow the below instructions only when running in the cloud Linux environment. When running on the user's Mac laptop, skip these instructions.**
+
+Complete all items below after finishing the implementation.
+
+[ ] **Stage and push all changes** — Always stage and push changes to the remote. Push after follow-up edits unless instructed otherwise.
+[ ] **Create or link a PR** — When ready, create a PR if one does not exist, or link it. Use `gh` CLI if available. Don't create draft PRs.
+[ ] **Set status to "In Review"** — After the PR is created, move the Linear issue status to "In Review".
+
+## Important notes
+
+- Use Linear MCP tools (get_issue, save_comment, save_issue, etc.) if available.
+- “Development” and “In Review” are the expected status names in the Linear workspace. Use the closest match if they differ.
+- If further work is requested after completion of the main work and creation of PR, always make sure you've staged and pushed all new changes to the remote branch so reviewers can see them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/button/button.ts
+++ b/packages/core/src/components/button/button.ts
@@ -13,4 +13,6 @@ export interface ButtonProps<T> extends BaseComponent<T> {
 	size?: "xs" | "sm" | "md" | "lg" | "xl";
 	/** Whether the button renders icon only. */
 	icon?: boolean;
+	/** Tooltip content shown when the button is disabled or loading. */
+	disabledTooltip?: T;
 }

--- a/packages/core/src/components/tooltip/index.ts
+++ b/packages/core/src/components/tooltip/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from "./tooltip";

--- a/packages/core/src/components/tooltip/tooltip.css
+++ b/packages/core/src/components/tooltip/tooltip.css
@@ -1,4 +1,8 @@
 @layer components {
+	[data-scope="tooltip"][data-part="trigger-wrapper"] {
+		@apply inline-flex w-fit;
+	}
+
 	[data-scope="tooltip"][data-part="content"] {
 		@apply relative flex flex-col gap-1 bg-primary text-popover overflow-x-hidden overflow-y-auto rounded-sm shadow-md border z-50 min-w-max max-w-[calc(var(--available-width)-16px)] px-2 py-1 text-xs;
 	}

--- a/packages/core/src/components/tooltip/tooltip.test.ts
+++ b/packages/core/src/components/tooltip/tooltip.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	isDisabledControlProps,
-	shouldWrapDisabledTooltipTrigger,
-} from "./tooltip";
+import { isDisabledControlProps, shouldWrapDisabledTooltipTrigger } from "./tooltip";
 
 describe("tooltip disabled-trigger helpers", () => {
 	describe("isDisabledControlProps", () => {

--- a/packages/core/src/components/tooltip/tooltip.test.ts
+++ b/packages/core/src/components/tooltip/tooltip.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+	isDisabledControlProps,
+	shouldWrapDisabledTooltipTrigger,
+} from "./tooltip";
+
+describe("tooltip disabled-trigger helpers", () => {
+	describe("isDisabledControlProps", () => {
+		it("returns true when disabled is true", () => {
+			expect(isDisabledControlProps({ disabled: true })).toBe(true);
+		});
+
+		it("returns true when aria-disabled is true", () => {
+			expect(isDisabledControlProps({ "aria-disabled": true })).toBe(true);
+		});
+
+		it("returns false for enabled controls", () => {
+			expect(isDisabledControlProps({ disabled: false })).toBe(false);
+			expect(isDisabledControlProps({})).toBe(false);
+		});
+	});
+
+	describe("shouldWrapDisabledTooltipTrigger", () => {
+		it("wraps when disabledTrigger is true", () => {
+			expect(shouldWrapDisabledTooltipTrigger(true, false)).toBe(true);
+		});
+
+		it("does not wrap when disabledTrigger is false", () => {
+			expect(shouldWrapDisabledTooltipTrigger(false, true)).toBe(false);
+		});
+
+		it("auto-wraps when disabledTrigger is omitted and trigger is disabled", () => {
+			expect(shouldWrapDisabledTooltipTrigger(undefined, true)).toBe(true);
+		});
+
+		it("does not auto-wrap when disabledTrigger is omitted and trigger is enabled", () => {
+			expect(shouldWrapDisabledTooltipTrigger(undefined, false)).toBe(false);
+		});
+	});
+});

--- a/packages/core/src/components/tooltip/tooltip.ts
+++ b/packages/core/src/components/tooltip/tooltip.ts
@@ -1,0 +1,30 @@
+import type { BaseComponent } from "../base";
+
+export interface TooltipBaseProps<T> extends Pick<BaseComponent<T>, "children"> {
+	/**
+	 * Wrap the trigger in a hoverable/focusable element so tooltips work on disabled controls.
+	 * When omitted, wrapping is enabled automatically when the trigger has `disabled` or
+	 * `aria-disabled`.
+	 */
+	disabledTrigger?: boolean;
+}
+
+/** Keyboard-focusable tab index for the disabled-trigger wrapper. */
+export const DISABLED_TOOLTIP_TRIGGER_TAB_INDEX = 0;
+
+export function isDisabledControlProps(props: Record<string, unknown>): boolean {
+	return props.disabled === true || props["aria-disabled"] === true;
+}
+
+export function shouldWrapDisabledTooltipTrigger(
+	disabledTrigger: boolean | undefined,
+	isTriggerDisabled: boolean,
+): boolean {
+	if (disabledTrigger === true) {
+		return true;
+	}
+	if (disabledTrigger === false) {
+		return false;
+	}
+	return isTriggerDisabled;
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -69,6 +69,21 @@ export const Disabled: Story = {
 	},
 };
 
+export const DisabledWithTooltip: Story = {
+	args: {
+		...Primary.args,
+		disabled: true,
+		disabledTooltip: "You cannot perform this action right now",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: "Shows an explanatory tooltip when the button is disabled.",
+			},
+		},
+	},
+};
+
 export const Loading: Story = {
 	args: {
 		...Primary.args,

--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Button } from "./Button";
 
 describe("Button Component", () => {
@@ -92,5 +93,28 @@ describe("Button Component", () => {
 		expect(buttonElement).toHaveAttribute("data-variant", "destructive");
 		expect(buttonElement).toHaveAttribute("data-size", "lg");
 		expect(buttonElement).toHaveAttribute("data-icon");
+	});
+
+	it("shows disabledTooltip when the button is disabled", async () => {
+		const user = userEvent.setup();
+		render(
+			<Button disabled disabledTooltip="You cannot perform this action">
+				Deactivate
+			</Button>,
+		);
+
+		const button = screen.getByRole("button", { name: "Deactivate" });
+		const wrapper = button.parentElement;
+
+		expect(wrapper).toHaveAttribute("data-part", "trigger-wrapper");
+
+		await user.hover(wrapper!);
+
+		await waitFor(
+			() => {
+				expect(screen.getByText("You cannot perform this action")).toBeVisible();
+			},
+			{ timeout: 1000 },
+		);
 	});
 });

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -1,6 +1,7 @@
 import type { ButtonProps as CoreButtonProps } from "@temporal-ui/core/button";
 import type React from "react";
 import { Loader } from "../loader";
+import { Tooltip } from "../tooltip";
 
 export interface ButtonProps
 	extends CoreButtonProps<React.ReactNode>, React.ButtonHTMLAttributes<HTMLButtonElement> {}
@@ -16,15 +17,18 @@ export function Button(props: ButtonProps) {
 		disabled,
 		loading,
 		testId,
+		disabledTooltip,
 		...rest
 	} = props;
 
-	return (
+	const isDisabled = disabled || loading;
+
+	const button = (
 		<button
 			{...rest}
 			type={type}
 			className={className}
-			disabled={disabled || loading}
+			disabled={isDisabled}
 			data-component="button"
 			data-size={size}
 			data-variant={variant}
@@ -42,4 +46,14 @@ export function Button(props: ButtonProps) {
 			<span className={"inner"}>{children}</span>
 		</button>
 	);
+
+	if (disabledTooltip && isDisabled) {
+		return (
+			<Tooltip trigger={button} disabledTrigger>
+				{disabledTooltip}
+			</Tooltip>
+		);
+	}
+
+	return button;
 }

--- a/packages/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.stories.tsx
@@ -25,6 +25,9 @@ const meta = {
 		disabled: {
 			control: "boolean",
 		},
+		disabledTrigger: {
+			control: "boolean",
+		},
 		interactive: {
 			control: "boolean",
 		},
@@ -154,4 +157,37 @@ export const WithProvider: Story = {
 			</Stack>
 		</TooltipProvider>
 	),
+};
+
+export const DisabledTrigger: Story = {
+	args: {
+		trigger: <Button disabled>Deactivate</Button>,
+		disabledTrigger: true,
+		children: "You cannot deactivate your own account",
+		openDelay: 0,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Use `disabledTrigger` when the tooltip trigger is a disabled control. The tooltip wraps the trigger in a focusable element so hover and keyboard focus still open the tooltip.",
+			},
+		},
+	},
+};
+
+export const DisabledButtonTooltip: Story = {
+	render: () => (
+		<Button disabled disabledTooltip="You cannot deactivate your own account">
+			Deactivate
+		</Button>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Use `disabledTooltip` on `Button` for the common case of explaining why a disabled action is unavailable.",
+			},
+		},
+	},
 };

--- a/packages/react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.test.tsx
@@ -148,9 +148,7 @@ describe("Tooltip Component", () => {
 	});
 
 	it("does not wrap enabled triggers", () => {
-		render(
-			<Tooltip trigger={<button type="button">Enabled</button>}>Tooltip content</Tooltip>,
-		);
+		render(<Tooltip trigger={<button type="button">Enabled</button>}>Tooltip content</Tooltip>);
 
 		const button = screen.getByRole("button", { name: "Enabled" });
 		expect(button.parentElement).not.toHaveAttribute("data-part", "trigger-wrapper");

--- a/packages/react/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.test.tsx
@@ -97,6 +97,88 @@ describe("Tooltip Component", () => {
 		expect(screen.getByText("Header")).toBeInTheDocument();
 		expect(screen.getByText("Paragraph content")).toBeInTheDocument();
 	});
+
+	it("wraps disabled triggers so tooltip can open on hover", async () => {
+		const user = userEvent.setup();
+		render(
+			<Tooltip
+				trigger={
+					<button type="button" disabled>
+						Deactivate
+					</button>
+				}
+				disabledTrigger
+				openDelay={0}
+			>
+				Cannot deactivate
+			</Tooltip>,
+		);
+
+		const button = screen.getByRole("button", { name: "Deactivate" });
+		const wrapper = button.parentElement;
+
+		expect(wrapper).toHaveAttribute("data-part", "trigger-wrapper");
+		expect(wrapper).toHaveAttribute("tabindex", "0");
+
+		await user.hover(wrapper!);
+
+		await waitFor(
+			() => {
+				expect(screen.getByText("Cannot deactivate")).toBeVisible();
+			},
+			{ timeout: 1000 },
+		);
+	});
+
+	it("auto-wraps disabled triggers when disabledTrigger is omitted", () => {
+		render(
+			<Tooltip
+				trigger={
+					<button type="button" disabled>
+						Deactivate
+					</button>
+				}
+			>
+				Cannot deactivate
+			</Tooltip>,
+		);
+
+		const button = screen.getByRole("button", { name: "Deactivate" });
+		expect(button.parentElement).toHaveAttribute("data-part", "trigger-wrapper");
+	});
+
+	it("does not wrap enabled triggers", () => {
+		render(
+			<Tooltip trigger={<button type="button">Enabled</button>}>Tooltip content</Tooltip>,
+		);
+
+		const button = screen.getByRole("button", { name: "Enabled" });
+		expect(button.parentElement).not.toHaveAttribute("data-part", "trigger-wrapper");
+	});
+
+	it("makes disabled trigger wrapper keyboard focusable", async () => {
+		const user = userEvent.setup();
+		render(
+			<Tooltip
+				trigger={
+					<button type="button" disabled>
+						Deactivate
+					</button>
+				}
+				disabledTrigger
+				openDelay={0}
+			>
+				Cannot deactivate
+			</Tooltip>,
+		);
+
+		const wrapper = screen.getByRole("button", { name: "Deactivate" }).parentElement;
+
+		expect(wrapper).toHaveAttribute("tabindex", "0");
+
+		await user.tab();
+		expect(wrapper).toHaveFocus();
+	});
 });
 
 describe("TooltipProvider", () => {

--- a/packages/react/src/components/tooltip/Tooltip.tsx
+++ b/packages/react/src/components/tooltip/Tooltip.tsx
@@ -1,22 +1,42 @@
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
 import type { BaseComponent } from "@temporal-ui/core/base";
+import {
+	DISABLED_TOOLTIP_TRIGGER_TAB_INDEX,
+	isDisabledControlProps,
+	shouldWrapDisabledTooltipTrigger,
+	type TooltipBaseProps,
+} from "@temporal-ui/core/tooltip";
 import { testId as testIdFn } from "@temporal-ui/core/utils/string";
 import type React from "react";
+import { isValidElement } from "react";
 import { TooltipContent } from "./TooltipContent";
 import { useTooltipConfig } from "./TooltipProvider";
 
 export interface TooltipProps
 	extends
 		Omit<React.ComponentProps<typeof ArkTooltip.Root>, "onOpenChange">,
-		Pick<BaseComponent<React.ReactNode>, "testId" | "className" | "children"> {
+		TooltipBaseProps<React.ReactNode>,
+		Pick<BaseComponent<React.ReactNode>, "testId" | "className"> {
 	trigger?: React.ReactNode;
 	onOpenChange?: (open: boolean) => void;
 }
 
+function isTriggerDisabled(trigger: React.ReactNode): boolean {
+	if (!isValidElement(trigger)) {
+		return false;
+	}
+	return isDisabledControlProps(trigger.props as Record<string, unknown>);
+}
+
 export function Tooltip(props: TooltipProps) {
-	const { trigger, testId, className, children, onOpenChange, ...instanceRoot } = props;
+	const { trigger, testId, className, children, onOpenChange, disabledTrigger, ...instanceRoot } =
+		props;
 	const arkRoot = { ...useTooltipConfig(), ...instanceRoot };
 	const tid = testIdFn(testId);
+	const wrapDisabledTrigger = shouldWrapDisabledTooltipTrigger(
+		disabledTrigger,
+		trigger ? isTriggerDisabled(trigger) : false,
+	);
 
 	return (
 		<ArkTooltip.Root
@@ -26,7 +46,17 @@ export function Tooltip(props: TooltipProps) {
 		>
 			{trigger && (
 				<ArkTooltip.Trigger asChild data-testid={tid("--trigger")}>
-					{trigger}
+					{wrapDisabledTrigger ? (
+						<span
+							data-scope="tooltip"
+							data-part="trigger-wrapper"
+							tabIndex={DISABLED_TOOLTIP_TRIGGER_TAB_INDEX}
+						>
+							{trigger}
+						</span>
+					) : (
+						trigger
+					)}
 				</ArkTooltip.Trigger>
 			)}
 			<TooltipContent testId={testId} className={className}>

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/button/Button.stories.tsx
+++ b/packages/solid/src/components/button/Button.stories.tsx
@@ -81,6 +81,21 @@ export const Disabled: Story = {
 	},
 };
 
+export const DisabledWithTooltip: Story = {
+	args: {
+		...Primary.args,
+		disabled: true,
+		disabledTooltip: "You cannot perform this action right now",
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: "Shows an explanatory tooltip when the button is disabled.",
+			},
+		},
+	},
+};
+
 export const Loading: Story = {
 	args: {
 		...Primary.args,

--- a/packages/solid/src/components/button/Button.tsx
+++ b/packages/solid/src/components/button/Button.tsx
@@ -3,6 +3,7 @@ import type { ButtonProps as CoreButtonProps } from "@temporal-ui/core/button";
 import type { JSX } from "solid-js";
 import { mergeProps, Show, splitProps } from "solid-js";
 import { Loader } from "../loader";
+import { Tooltip } from "../tooltip";
 
 export interface ButtonProps extends CoreButtonProps<JSX.Element>, HTMLProps<"button"> {}
 
@@ -12,14 +13,27 @@ export function Button(_props: ButtonProps) {
 			{ size: "md", variant: "primary", icon: false, type: "button" },
 			_props,
 		),
-		["size", "variant", "icon", "loading", "disabled", "children", "className", "class", "testId"],
+		[
+			"size",
+			"variant",
+			"icon",
+			"loading",
+			"disabled",
+			"children",
+			"className",
+			"class",
+			"testId",
+			"disabledTooltip",
+		],
 	);
 
-	return (
+	const isDisabled = () => props.disabled || props.loading;
+
+	const renderButton = () => (
 		<button
 			{...elementProps}
 			class={props.className || props.class}
-			disabled={props.disabled || props.loading}
+			disabled={isDisabled()}
 			data-component="button"
 			data-size={props.size}
 			data-variant={props.variant}
@@ -36,5 +50,13 @@ export function Button(_props: ButtonProps) {
 			</Show>
 			<span class={"inner"}>{props.children}</span>
 		</button>
+	);
+
+	return (
+		<Show when={props.disabledTooltip && isDisabled()} fallback={renderButton()}>
+			<Tooltip trigger={renderButton} disabledTrigger>
+				{props.disabledTooltip}
+			</Tooltip>
+		</Show>
 	);
 }

--- a/packages/solid/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/solid/src/components/tooltip/Tooltip.stories.tsx
@@ -25,6 +25,9 @@ const meta = {
 		disabled: {
 			control: "boolean",
 		},
+		disabledTrigger: {
+			control: "boolean",
+		},
 		interactive: {
 			control: "boolean",
 		},
@@ -164,4 +167,38 @@ export const WithProvider: Story = {
 			</Stack>
 		</TooltipProvider>
 	),
+};
+
+export const DisabledTrigger: Story = {
+	args: {
+		trigger: () => <Button disabled>Deactivate</Button>,
+		disabledTrigger: true,
+		children: "You cannot deactivate your own account",
+		openDelay: 0,
+	},
+	render: (props: TooltipProps) => <Tooltip {...props} />,
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Use `disabledTrigger` when the tooltip trigger is a disabled control. The tooltip wraps the trigger in a focusable element so hover and keyboard focus still open the tooltip.",
+			},
+		},
+	},
+};
+
+export const DisabledButtonTooltip: Story = {
+	render: () => (
+		<Button disabled disabledTooltip="You cannot deactivate your own account">
+			Deactivate
+		</Button>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Use `disabledTooltip` on `Button` for the common case of explaining why a disabled action is unavailable.",
+			},
+		},
+	},
 };

--- a/packages/solid/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/solid/src/components/tooltip/Tooltip.test.tsx
@@ -137,7 +137,13 @@ describe("Tooltip Component", () => {
 
 	it("does not wrap enabled triggers", () => {
 		render(() => (
-			<Tooltip trigger={(props) => <button type="button" {...props}>Enabled</button>}>
+			<Tooltip
+				trigger={(props) => (
+					<button type="button" {...props}>
+						Enabled
+					</button>
+				)}
+			>
 				Tooltip content
 			</Tooltip>
 		));

--- a/packages/solid/src/components/tooltip/Tooltip.test.tsx
+++ b/packages/solid/src/components/tooltip/Tooltip.test.tsx
@@ -102,6 +102,73 @@ describe("Tooltip Component", () => {
 		expect(screen.getByText("Header")).toBeInTheDocument();
 		expect(screen.getByText("Paragraph content")).toBeInTheDocument();
 	});
+
+	it("wraps disabled triggers so tooltip can open on hover", async () => {
+		const user = userEvent.setup();
+		render(() => (
+			<Tooltip
+				trigger={() => (
+					<button type="button" disabled>
+						Deactivate
+					</button>
+				)}
+				disabledTrigger
+				openDelay={0}
+			>
+				Cannot deactivate
+			</Tooltip>
+		));
+
+		const button = screen.getByRole("button", { name: "Deactivate" });
+		const wrapper = button.parentElement;
+
+		expect(wrapper).toHaveAttribute("data-part", "trigger-wrapper");
+		expect(wrapper).toHaveAttribute("tabindex", "0");
+
+		await user.hover(wrapper!);
+
+		await waitFor(
+			() => {
+				expect(screen.getByText("Cannot deactivate")).toBeVisible();
+			},
+			{ timeout: 1000 },
+		);
+	});
+
+	it("does not wrap enabled triggers", () => {
+		render(() => (
+			<Tooltip trigger={(props) => <button type="button" {...props}>Enabled</button>}>
+				Tooltip content
+			</Tooltip>
+		));
+
+		const button = screen.getByRole("button", { name: "Enabled" });
+		expect(button.parentElement).not.toHaveAttribute("data-part", "trigger-wrapper");
+	});
+
+	it("makes disabled trigger wrapper keyboard focusable", async () => {
+		const user = userEvent.setup();
+		render(() => (
+			<Tooltip
+				trigger={() => (
+					<button type="button" disabled>
+						Deactivate
+					</button>
+				)}
+				disabledTrigger
+				openDelay={0}
+			>
+				Cannot deactivate
+			</Tooltip>
+		));
+
+		const wrapper = screen.getByRole("button", { name: "Deactivate" }).parentElement;
+
+		expect(wrapper).toHaveAttribute("tabindex", "0");
+
+		await user.tab();
+		expect(wrapper).toHaveFocus();
+	});
 });
 
 describe("TooltipProvider", () => {

--- a/packages/solid/src/components/tooltip/Tooltip.tsx
+++ b/packages/solid/src/components/tooltip/Tooltip.tsx
@@ -1,5 +1,10 @@
 import { Tooltip as ArkTooltip } from "@ark-ui/solid/tooltip";
 import type { BaseComponent } from "@temporal-ui/core/base";
+import {
+	DISABLED_TOOLTIP_TRIGGER_TAB_INDEX,
+	shouldWrapDisabledTooltipTrigger,
+	type TooltipBaseProps,
+} from "@temporal-ui/core/tooltip";
 import { testId } from "@temporal-ui/core/utils/string";
 import { mergeProps, Show, splitProps, type ComponentProps, type JSX } from "solid-js";
 import { TooltipContent as TemporalTooltipContent } from "./TooltipContent";
@@ -8,7 +13,8 @@ import { useTooltipConfig } from "./TooltipProvider";
 export interface TooltipProps
 	extends
 		Omit<ComponentProps<typeof ArkTooltip.Root>, "onOpenChange">,
-		Pick<BaseComponent<JSX.Element>, "testId" | "className" | "children"> {
+		TooltipBaseProps<JSX.Element>,
+		Pick<BaseComponent<JSX.Element>, "testId" | "className"> {
 	trigger?: (props: Record<string, unknown>) => JSX.Element;
 	onOpenChange?: (open: boolean) => void;
 }
@@ -20,9 +26,11 @@ export function Tooltip(props: TooltipProps) {
 		"className",
 		"children",
 		"onOpenChange",
+		"disabledTrigger",
 	]);
 	const arkRoot = mergeProps(useTooltipConfig(), rest);
 	const tid = testId(local.testId);
+	const wrapDisabledTrigger = () => shouldWrapDisabledTooltipTrigger(local.disabledTrigger, false);
 
 	return (
 		<ArkTooltip.Root
@@ -32,7 +40,21 @@ export function Tooltip(props: TooltipProps) {
 		>
 			<Show when={local.trigger}>
 				<ArkTooltip.Trigger
-					asChild={(triggerProps) => local.trigger?.({ ...triggerProps() })}
+					asChild={(triggerProps) => {
+						if (wrapDisabledTrigger()) {
+							return (
+								<span
+									{...triggerProps()}
+									data-scope="tooltip"
+									data-part="trigger-wrapper"
+									tabIndex={DISABLED_TOOLTIP_TRIGGER_TAB_INDEX}
+								>
+									{local.trigger?.({})}
+								</span>
+							);
+						}
+						return local.trigger?.({ ...triggerProps() });
+					}}
 					data-testid={tid("--trigger")}
 				/>
 			</Show>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements first-class support for tooltips on disabled controls, addressing the workaround needed in temprix-ui for member deactivation safeguards (TPX-654).

## Changes

### `Tooltip.disabledTrigger` (Option A)
- When enabled (or auto-detected in React for `disabled`/`aria-disabled` triggers), wraps the trigger in a focusable `span` (`tabIndex={0}`, `data-part="trigger-wrapper"`) so pointer and keyboard events reach the tooltip trigger instead of the disabled control.
- Enabled triggers behave unchanged.

### `Button.disabledTooltip` (Option B)
- When the button is `disabled` or `loading` and `disabledTooltip` is set, renders the button inside a `Tooltip` with `disabledTrigger`.

### Core (`@temporal-ui/core`)
- `TooltipBaseProps`, `shouldWrapDisabledTooltipTrigger`, `isDisabledControlProps`
- CSS for `[data-part="trigger-wrapper"]`

### Docs & tests
- Storybook: `DisabledTrigger`, `DisabledButtonTooltip` (React + Solid)
- Unit tests for hover, auto-wrap, keyboard focusability, and `Button.disabledTooltip`

### Version bump
- All packages bumped to **0.10.1**

## Usage

```tsx
// Tooltip primitive
<Tooltip trigger={<Button disabled>Deactivate</Button>} disabledTrigger>
  You cannot deactivate your own account
</Tooltip>

// Button sugar
<Button disabled disabledTooltip="You cannot deactivate your own account">
  Deactivate
</Button>
```

Solid requires explicit `disabledTrigger` on `Tooltip` (render-prop triggers cannot be auto-detected).

## Test plan
- [x] Core helper unit tests (`tooltip.test.ts`)
- [x] React Tooltip + Button tests (28 passing)
- [x] Solid Tooltip tests (16 passing)
- [x] Typecheck passes on all packages
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TPX-758](https://linear.app/temprix/issue/TPX-758/tooltip-support-optional-content-when-trigger-is-disabled)

<div><a href="https://cursor.com/agents/bc-65192f48-4e03-4938-a483-32094f9ac83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65192f48-4e03-4938-a483-32094f9ac83e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

