### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,10 @@ When given a linear issue ID (e.g. `TPX-412`), you must follow instructions in `
 - Do not use `npm install`, `yarn`, or `pnpm`
 - Do not run `eslint` or `prettier`; use Biome
 - Do not run `lint` or `typecheck` without first running `build` (or expect a build to run as part of the pipeline)
+
+## Cursor Cloud specific instructions
+
+- **Tooling drift**: Some docs (README/CLAUDE.md and sections above) still say Biome and `bun@1.2.23`. The repo actually uses **oxlint** (`bun run lint`), **oxfmt** (`bun run format`), `tsgo` for typecheck, and `bun@1.3.12` (see `packageManager` in `package.json`). Trust `package.json` over the prose docs.
+- **`bun install` postinstall fails here (expected)**: The root `postinstall` runs `lefthook install`, which exits 1 in Cursor Cloud because git `core.hooksPath` is set to Cursor's agent hooks and lefthook refuses to override it. Dependencies still install fully — only the git-hook step fails. The startup update script therefore uses `bun install --ignore-scripts`; if you run a plain `bun install` manually and it only errors on `lefthook install`, ignore that error.
+- **The "app" is Storybook** (this is a component library, no backend/DB): React on port 6006 (`bun run react`), Solid on port 6007 (`bun run solid`). Both are long-running dev servers — start them in a background/tmux session. Verify with `curl -s -o /dev/null -w '%{http_code}' http://localhost:6006/`.
+- After changing the selected story in the Storybook sidebar, give the canvas iframe a moment to load; a transiently restarted server can show a briefly blank canvas.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Temporal UI monorepo (Bun + Turbo, `core`/`react`/`solid` packages) so cloud agents can build, lint, typecheck, test, and run the Storybook dev servers.

- Installed **Bun 1.3.12** (matches `packageManager`) and workspace dependencies.
- Configured the startup update script: `bun install --ignore-scripts`.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious gotchas.

## Why `--ignore-scripts`

The root `postinstall` runs `lefthook install`, which exits 1 in Cursor Cloud because git `core.hooksPath` points at Cursor's agent hooks and lefthook refuses to override it. Dependencies still install fully; only the git-hook step fails. `--ignore-scripts` avoids the failure and still yields a working build (validated from a clean `node_modules`).

## Verification

All run against the repo:

- `bun run build` — 3 packages built
- `bun run lint` (oxlint) — clean
- `bun run typecheck` (tsgo) — clean
- `bun run test` — core + react (181) + solid (176) all pass
- `bun run react` (Storybook :6006) and `bun run solid` (Storybook :6007) — both serve HTTP 200

Hello-world: rendered and interacted with live components in the React Storybook (Button, Checkbox, TextInput), changed a prop via the Controls panel with live update.

<a href="https://cursor.com/agents/bc-151555b6-f290-4b33-8847-c8213889b551/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_storybook_manager_ui.mp4"><img src="https://cursor.com/artifacts/c/art-e2213bef-9bf7-4473-9659-a79149c23737" alt="react_storybook_manager_ui.mp4" /></a>

![Button rendered in canvas](https://cursor.com/artifacts/c/art-2d6b41b5-b6c6-49ea-b106-0ff02834ab24)
![Live control update](https://cursor.com/artifacts/c/art-b84208d3-1f65-4e36-b021-c9c1f2186a64)
![Checkbox toggled](https://cursor.com/artifacts/c/art-7574834c-64ec-49fb-ab00-340145db465f)

Note: docs (README/CLAUDE.md) still reference Biome/`bun@1.2.23`, but the repo actually uses oxlint/oxfmt and `bun@1.3.12` — captured in AGENTS.md.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-151555b6-f290-4b33-8847-c8213889b551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-151555b6-f290-4b33-8847-c8213889b551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

