### PR TITLE
feat(select): Linear-style dropdown aligned to selected value

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,10 +20,11 @@
     },
     "packages/core": {
       "name": "@temporal-ui/core",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "devDependencies": {
         "@tsdown/css": "0.22.1",
         "clean-package": "2.2.0",
+        "happy-dom": "20.9.0",
         "rimraf": "6.1.3",
         "tsdown": "0.22.1",
         "typescript": "6.0.3",
@@ -32,7 +33,7 @@
     },
     "packages/react": {
       "name": "@temporal-ui/react",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@ark-ui/react": "5.37.0",
         "@tanstack/react-table": "8.21.3",
@@ -68,7 +69,7 @@
     },
     "packages/solid": {
       "name": "@temporal-ui/solid",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@ark-ui/solid": "5.37.0",
         "@tanstack/solid-table": "8.21.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
 	"devDependencies": {
 		"@tsdown/css": "0.22.1",
 		"clean-package": "2.2.0",
+		"happy-dom": "20.9.0",
 		"rimraf": "6.1.3",
 		"tsdown": "0.22.1",
 		"typescript": "6.0.3",

--- a/packages/core/src/components/select/align-select.test.ts
+++ b/packages/core/src/components/select/align-select.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it } from "vitest";
+import {
+	alignSelectDropdown,
+	getSelectScrollState,
+	getSelectedSelectItem,
+	getSelectTriggerForContent,
+} from "./align-select";
+import { createLinearSelectPositioning } from "./create-linear-positioning";
+import { startSelectCaretAutoScroll } from "./scroll-carets";
+
+function mountSelectFixture(options?: {
+	selectedIndex?: number;
+	itemCount?: number;
+	triggerTop?: number;
+}) {
+	const itemCount = options?.itemCount ?? 7;
+	const selectedIndex = options?.selectedIndex;
+	const triggerTop = options?.triggerTop ?? 200;
+
+	document.body.innerHTML = "";
+	Object.defineProperty(document.documentElement, "clientHeight", {
+		configurable: true,
+		value: 800,
+	});
+	Object.defineProperty(document.documentElement, "clientWidth", {
+		configurable: true,
+		value: 1200,
+	});
+
+	const trigger = document.createElement("button");
+	trigger.setAttribute("data-scope", "select");
+	trigger.setAttribute("data-part", "trigger");
+	trigger.id = "trigger";
+	Object.defineProperty(trigger, "getBoundingClientRect", {
+		configurable: true,
+		value: () => ({
+			top: triggerTop,
+			bottom: triggerTop + 36,
+			left: 100,
+			right: 220,
+			width: 120,
+			height: 36,
+			x: 100,
+			y: triggerTop,
+			toJSON() {},
+		}),
+	});
+
+	const content = document.createElement("div");
+	content.setAttribute("data-part", "content");
+	content.id = "select-content";
+	content.style.position = "relative";
+
+	const positioner = document.createElement("div");
+	positioner.setAttribute("data-part", "positioner");
+	positioner.style.setProperty("--x", "100px");
+	positioner.style.setProperty("--y", `${triggerTop + 36}px`);
+	Object.defineProperty(positioner, "getBoundingClientRect", {
+		configurable: true,
+		value: () => {
+			const y = parseFloat(positioner.style.getPropertyValue("--y") || "0");
+			const x = parseFloat(positioner.style.getPropertyValue("--x") || "0");
+			const height = Number.parseFloat(content.style.height || content.style.maxHeight || "200") || 200;
+			return {
+				top: y,
+				bottom: y + height,
+				left: x,
+				right: x + 160,
+				width: 160,
+				height,
+				x,
+				y,
+				toJSON() {},
+			};
+		},
+	});
+
+	const list = document.createElement("div");
+	list.setAttribute("data-component", "select");
+	list.setAttribute("data-slot", "list");
+	Object.defineProperty(list, "clientHeight", {
+		configurable: true,
+		get() {
+			const cap =
+				Number.parseFloat(content.style.height || content.style.maxHeight || "9999") || 9999;
+			return Math.min(list.scrollHeight, cap);
+		},
+	});
+
+	for (let i = 0; i < itemCount; i++) {
+		const item = document.createElement("div");
+		item.setAttribute("data-part", "item");
+		item.setAttribute("data-state", i === selectedIndex ? "checked" : "unchecked");
+		item.textContent = `Item ${i}`;
+		Object.defineProperty(item, "offsetTop", { value: i * 32, configurable: true });
+		Object.defineProperty(item, "offsetHeight", { value: 32, configurable: true });
+		list.appendChild(item);
+	}
+
+	Object.defineProperty(list, "scrollHeight", {
+		configurable: true,
+		get() {
+			return itemCount * 32;
+		},
+	});
+
+	content.appendChild(list);
+	positioner.appendChild(content);
+	trigger.setAttribute("aria-controls", content.id);
+
+	document.body.append(trigger, positioner);
+
+	return { trigger, positioner, content, list };
+}
+
+describe("alignSelectDropdown", () => {
+	it("aligns the selected item with the trigger and stays in the viewport", () => {
+		const { trigger, positioner, content, list } = mountSelectFixture({ selectedIndex: 3 });
+
+		const result = alignSelectDropdown({
+			positioner,
+			content,
+			trigger,
+			selectedItem: getSelectedSelectItem(content),
+			overflowPadding: 8,
+		});
+
+		const y = parseFloat(positioner.style.getPropertyValue("--y"));
+		// trigger top (200) - selected offset (96) = 104
+		expect(y).toBeCloseTo(104, 0);
+		expect(list.scrollTop).toBe(0);
+		expect(result.canScrollUp).toBe(false);
+	});
+
+	it("clamps to the viewport and scrolls when the menu would overflow the top", () => {
+		const { trigger, positioner, content, list } = mountSelectFixture({
+			selectedIndex: 20,
+			itemCount: 30,
+			triggerTop: 40,
+		});
+
+		const result = alignSelectDropdown({
+			positioner,
+			content,
+			trigger,
+			selectedItem: getSelectedSelectItem(content),
+			overflowPadding: 8,
+			maxHeight: 200,
+		});
+
+		const y = parseFloat(positioner.style.getPropertyValue("--y"));
+		expect(y).toBeGreaterThanOrEqual(8);
+		expect(list.scrollTop).toBeGreaterThan(0);
+		expect(result.canScrollUp || result.canScrollDown).toBe(true);
+	});
+});
+
+describe("getSelectTriggerForContent", () => {
+	it("finds the trigger via aria-controls", () => {
+		const { trigger, content } = mountSelectFixture();
+		expect(getSelectTriggerForContent(content)).toBe(trigger);
+	});
+});
+
+describe("createLinearSelectPositioning", () => {
+	it("chains user updatePosition and then aligns", async () => {
+		const { trigger, positioner, content } = mountSelectFixture({ selectedIndex: 2 });
+		let userCalled = false;
+
+		const positioning = createLinearSelectPositioning({
+			positioning: {
+				updatePosition: async ({ updatePosition }) => {
+					userCalled = true;
+					await updatePosition();
+				},
+			},
+		});
+
+		await positioning.updatePosition?.({
+			updatePosition: async () => {
+				positioner.style.setProperty("--y", "236px");
+			},
+			floatingElement: positioner,
+		});
+
+		expect(userCalled).toBe(true);
+		expect(getSelectTriggerForContent(content)).toBe(trigger);
+		expect(parseFloat(positioner.style.getPropertyValue("--y"))).toBeLessThan(236);
+	});
+});
+
+describe("startSelectCaretAutoScroll", () => {
+	it("scrolls the scroller and stops at the edge", async () => {
+		const { list } = mountSelectFixture({ itemCount: 40 });
+		Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
+		list.scrollTop = 50;
+
+		await new Promise<void>((resolve) => {
+			const stop = startSelectCaretAutoScroll({
+				scroller: list,
+				direction: "up",
+				step: 20,
+				intervalMs: 5,
+				onScroll: (state) => {
+					if (!state.canScrollUp) {
+						stop();
+						resolve();
+					}
+				},
+			});
+			setTimeout(() => {
+				stop();
+				resolve();
+			}, 200);
+		});
+
+		expect(list.scrollTop).toBeLessThanOrEqual(50);
+		expect(getSelectScrollState(list).canScrollUp).toBe(false);
+	});
+});

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -60,7 +60,6 @@ function isSelectedItemInView(scroller: HTMLElement, selectedItem: HTMLElement):
 	const bottom = top + selectedItem.offsetHeight;
 	const viewTop = scroller.scrollTop;
 	const viewBottom = viewTop + scroller.clientHeight;
-	// Partially visible is enough to consider alignment successful.
 	return bottom > viewTop + SCROLL_EDGE_TOLERANCE && top < viewBottom - SCROLL_EDGE_TOLERANCE;
 }
 
@@ -87,7 +86,6 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 		return getSelectScrollState(scroller);
 	}
 
-	// Unlock if layout finished later and the selected row is no longer in view.
 	if (
 		alreadyAligned &&
 		selectedItem &&
@@ -103,21 +101,24 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 	const viewportWidth = document.documentElement.clientWidth;
 	const availableHeight = Math.max(0, viewportHeight - overflowPadding * 2);
 
-	content.style.height = "auto";
-	content.style.maxHeight = "none";
-	scroller.style.height = "auto";
+	const previousMaxHeight = scroller.style.maxHeight;
+	const previousContentMaxHeight = content.style.maxHeight;
 	scroller.style.maxHeight = "none";
-	const fullHeight = Math.max(scroller.scrollHeight, scroller.offsetHeight);
+	content.style.maxHeight = "none";
+	content.style.height = "auto";
+	const fullHeight = Math.max(scroller.scrollHeight, content.scrollHeight);
+	scroller.style.maxHeight = previousMaxHeight;
+	content.style.maxHeight = previousContentMaxHeight;
 
 	const constrainedHeight = Math.min(
 		fullHeight,
 		availableHeight,
 		maxHeight ?? Number.POSITIVE_INFINITY,
 	);
-	const needsScroll = fullHeight > constrainedHeight + SCROLL_EDGE_TOLERANCE;
 
+	scroller.style.maxHeight = `${constrainedHeight}px`;
 	content.style.maxHeight = `${constrainedHeight}px`;
-	content.style.height = needsScroll ? `${constrainedHeight}px` : "auto";
+	content.style.height = "auto";
 
 	const positionerRect = positioner.getBoundingClientRect();
 	const currentY = parseFloat(positioner.style.getPropertyValue("--y") || "0") || 0;

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -28,6 +28,22 @@ function getSelectScroller(content: HTMLElement): HTMLElement {
 	return content.querySelector<HTMLElement>('[data-component="select"][data-slot="list"]') ?? content;
 }
 
+function triggerHasSelectedValue(trigger: HTMLElement): boolean {
+	if (trigger.getAttribute("data-placeholder-shown") != null) return false;
+	const valueText = trigger.querySelector<HTMLElement>('[data-part="value-text"]');
+	if (!valueText) return true;
+	return valueText.getAttribute("data-placeholder-shown") == null;
+}
+
+function isAlignmentReady(content: HTMLElement, trigger: HTMLElement, selectedItem: HTMLElement | null) {
+	const scroller = getSelectScroller(content);
+	const hasItems = content.querySelector('[data-part="item"]') != null;
+	if (!hasItems || scroller.scrollHeight === 0) return false;
+	if (triggerHasSelectedValue(trigger) && !selectedItem) return false;
+	if (selectedItem && selectedItem.offsetHeight <= 0) return false;
+	return true;
+}
+
 /**
  * Positions a select dropdown Linear-style: the menu overlays the trigger and
  * the selected item is vertically aligned with it, clamped to the viewport.
@@ -43,6 +59,13 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 	} = options;
 
 	const scroller = getSelectScroller(content);
+	const ready = isAlignmentReady(content, trigger, selectedItem);
+	const alreadyAligned = content.dataset.linearAligned === "true";
+
+	if (!ready && !alreadyAligned) {
+		return getSelectScrollState(scroller);
+	}
+
 	const triggerRect = trigger.getBoundingClientRect();
 	const viewportHeight = document.documentElement.clientHeight;
 	const viewportWidth = document.documentElement.clientWidth;
@@ -63,15 +86,18 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 	content.style.maxHeight = `${constrainedHeight}px`;
 	content.style.height = needsScroll ? `${constrainedHeight}px` : "auto";
 
-	const alreadyAligned = content.dataset.linearAligned === "true";
-	const itemOffset = selectedItem?.offsetTop ?? 0;
-	let nextTop = triggerRect.top - itemOffset;
-	let scrollTop = alreadyAligned ? scroller.scrollTop : 0;
-
-	const minTop = overflowPadding;
-	const maxTop = viewportHeight - constrainedHeight - overflowPadding;
+	const positionerRect = positioner.getBoundingClientRect();
+	const currentY = parseFloat(positioner.style.getPropertyValue("--y") || "0") || 0;
+	const currentX = parseFloat(positioner.style.getPropertyValue("--x") || "0") || 0;
 
 	if (!alreadyAligned) {
+		const itemOffset = selectedItem?.offsetTop ?? 0;
+		let nextTop = triggerRect.top - itemOffset;
+		let scrollTop = 0;
+
+		const minTop = overflowPadding;
+		const maxTop = viewportHeight - constrainedHeight - overflowPadding;
+
 		if (nextTop < minTop) {
 			scrollTop = minTop - nextTop;
 			nextTop = minTop;
@@ -90,20 +116,11 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 				scroller.scrollTop = itemBottom - constrainedHeight;
 			}
 		}
-	} else if (nextTop < minTop) {
-		nextTop = minTop;
-	} else if (nextTop > maxTop) {
-		nextTop = Math.max(minTop, maxTop);
+
+		const deltaY = nextTop - positionerRect.top;
+		positioner.style.setProperty("--y", `${currentY + deltaY}px`);
+		content.dataset.linearAligned = "true";
 	}
-
-	content.dataset.linearAligned = "true";
-
-	const positionerRect = positioner.getBoundingClientRect();
-	const currentY = parseFloat(positioner.style.getPropertyValue("--y") || "0") || 0;
-	const currentX = parseFloat(positioner.style.getPropertyValue("--x") || "0") || 0;
-
-	const deltaY = nextTop - positionerRect.top;
-	positioner.style.setProperty("--y", `${currentY + deltaY}px`);
 
 	const menuWidth = positionerRect.width || content.offsetWidth;
 	let nextLeft = positionerRect.left;

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -63,31 +63,40 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 	content.style.maxHeight = `${constrainedHeight}px`;
 	content.style.height = needsScroll ? `${constrainedHeight}px` : "auto";
 
+	const alreadyAligned = content.dataset.linearAligned === "true";
 	const itemOffset = selectedItem?.offsetTop ?? 0;
 	let nextTop = triggerRect.top - itemOffset;
-	let scrollTop = 0;
+	let scrollTop = alreadyAligned ? scroller.scrollTop : 0;
 
 	const minTop = overflowPadding;
 	const maxTop = viewportHeight - constrainedHeight - overflowPadding;
 
-	if (nextTop < minTop) {
-		scrollTop = minTop - nextTop;
+	if (!alreadyAligned) {
+		if (nextTop < minTop) {
+			scrollTop = minTop - nextTop;
+			nextTop = minTop;
+		} else if (nextTop > maxTop) {
+			nextTop = Math.max(minTop, maxTop);
+		}
+
+		scroller.scrollTop = scrollTop;
+
+		if (selectedItem) {
+			const itemTop = selectedItem.offsetTop;
+			const itemBottom = itemTop + selectedItem.offsetHeight;
+			if (itemTop < scroller.scrollTop) {
+				scroller.scrollTop = itemTop;
+			} else if (itemBottom > scroller.scrollTop + constrainedHeight) {
+				scroller.scrollTop = itemBottom - constrainedHeight;
+			}
+		}
+	} else if (nextTop < minTop) {
 		nextTop = minTop;
 	} else if (nextTop > maxTop) {
 		nextTop = Math.max(minTop, maxTop);
 	}
 
-	scroller.scrollTop = scrollTop;
-
-	if (selectedItem) {
-		const itemTop = selectedItem.offsetTop;
-		const itemBottom = itemTop + selectedItem.offsetHeight;
-		if (itemTop < scroller.scrollTop) {
-			scroller.scrollTop = itemTop;
-		} else if (itemBottom > scroller.scrollTop + constrainedHeight) {
-			scroller.scrollTop = itemBottom - constrainedHeight;
-		}
-	}
+	content.dataset.linearAligned = "true";
 
 	const positionerRect = positioner.getBoundingClientRect();
 	const currentY = parseFloat(positioner.style.getPropertyValue("--y") || "0") || 0;
@@ -110,7 +119,19 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 		positioner.style.setProperty("--x", `${currentX + deltaX}px`);
 	}
 
-	return getSelectScrollState(scroller);
+	const state = getSelectScrollState(scroller);
+	content.dispatchEvent(
+		new CustomEvent("temporal-ui:select-aligned", {
+			bubbles: true,
+			detail: state,
+		}),
+	);
+	return state;
+}
+
+/** Clears one-shot alignment state so the next open can re-align to the selection. */
+export function resetSelectLinearAlignment(content: HTMLElement | null | undefined) {
+	content?.removeAttribute("data-linear-aligned");
 }
 
 export function getSelectScrollState(scroller: HTMLElement): AlignSelectDropdownResult {

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -13,6 +13,11 @@ export interface AlignSelectDropdownOptions {
 	 * When omitted, the menu aligns to the top of the trigger (first-item style).
 	 */
 	selectedItem?: HTMLElement | null;
+	/**
+	 * Whether the select currently has a selected value.
+	 * When true, alignment waits until `selectedItem` is present in the DOM.
+	 */
+	hasValue?: boolean;
 	/** Viewport edge padding in CSS pixels. @default 8 */
 	overflowPadding?: number;
 	/** Optional hard cap on menu height (in addition to viewport). */
@@ -31,15 +36,21 @@ function getSelectScroller(content: HTMLElement): HTMLElement {
 function triggerHasSelectedValue(trigger: HTMLElement): boolean {
 	if (trigger.getAttribute("data-placeholder-shown") != null) return false;
 	const valueText = trigger.querySelector<HTMLElement>('[data-part="value-text"]');
-	if (!valueText) return true;
-	return valueText.getAttribute("data-placeholder-shown") == null;
+	if (!valueText) return false;
+	return valueText.getAttribute("data-placeholder-shown") == null && (valueText.textContent?.trim().length ?? 0) > 0;
 }
 
-function isAlignmentReady(content: HTMLElement, trigger: HTMLElement, selectedItem: HTMLElement | null) {
+function isAlignmentReady(
+	content: HTMLElement,
+	trigger: HTMLElement,
+	selectedItem: HTMLElement | null,
+	hasValue?: boolean,
+) {
 	const scroller = getSelectScroller(content);
 	const hasItems = content.querySelector('[data-part="item"]') != null;
 	if (!hasItems || scroller.scrollHeight === 0) return false;
-	if (triggerHasSelectedValue(trigger) && !selectedItem) return false;
+	const expectsSelection = hasValue ?? triggerHasSelectedValue(trigger);
+	if (expectsSelection && !selectedItem) return false;
 	if (selectedItem && selectedItem.offsetHeight <= 0) return false;
 	return true;
 }
@@ -54,12 +65,13 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 		content,
 		trigger,
 		selectedItem = null,
+		hasValue,
 		overflowPadding = DEFAULT_OVERFLOW_PADDING,
 		maxHeight,
 	} = options;
 
 	const scroller = getSelectScroller(content);
-	const ready = isAlignmentReady(content, trigger, selectedItem);
+	const ready = isAlignmentReady(content, trigger, selectedItem, hasValue);
 	const alreadyAligned = content.dataset.linearAligned === "true";
 
 	if (!ready && !alreadyAligned) {

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -1,0 +1,151 @@
+const DEFAULT_OVERFLOW_PADDING = 8;
+const SCROLL_EDGE_TOLERANCE = 1;
+
+export interface AlignSelectDropdownOptions {
+	/** Floating positioner element (`[data-part="positioner"]`). */
+	positioner: HTMLElement;
+	/** Select content element (`[data-part="content"]`). */
+	content: HTMLElement;
+	/** Select trigger element. */
+	trigger: HTMLElement;
+	/**
+	 * Currently selected item element, if any.
+	 * When omitted, the menu aligns to the top of the trigger (first-item style).
+	 */
+	selectedItem?: HTMLElement | null;
+	/** Viewport edge padding in CSS pixels. @default 8 */
+	overflowPadding?: number;
+	/** Optional hard cap on menu height (in addition to viewport). */
+	maxHeight?: number;
+}
+
+export interface AlignSelectDropdownResult {
+	canScrollUp: boolean;
+	canScrollDown: boolean;
+}
+
+function getSelectScroller(content: HTMLElement): HTMLElement {
+	return content.querySelector<HTMLElement>('[data-component="select"][data-slot="list"]') ?? content;
+}
+
+/**
+ * Positions a select dropdown Linear-style: the menu overlays the trigger and
+ * the selected item is vertically aligned with it, clamped to the viewport.
+ */
+export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignSelectDropdownResult {
+	const {
+		positioner,
+		content,
+		trigger,
+		selectedItem = null,
+		overflowPadding = DEFAULT_OVERFLOW_PADDING,
+		maxHeight,
+	} = options;
+
+	const scroller = getSelectScroller(content);
+	const triggerRect = trigger.getBoundingClientRect();
+	const viewportHeight = document.documentElement.clientHeight;
+	const viewportWidth = document.documentElement.clientWidth;
+	const availableHeight = Math.max(0, viewportHeight - overflowPadding * 2);
+
+	content.style.height = "auto";
+	content.style.maxHeight = "none";
+	scroller.style.maxHeight = "none";
+	const fullHeight = scroller.scrollHeight;
+
+	const constrainedHeight = Math.min(
+		fullHeight,
+		availableHeight,
+		maxHeight ?? Number.POSITIVE_INFINITY,
+	);
+	const needsScroll = fullHeight > constrainedHeight + SCROLL_EDGE_TOLERANCE;
+
+	content.style.maxHeight = `${constrainedHeight}px`;
+	content.style.height = needsScroll ? `${constrainedHeight}px` : "auto";
+
+	const itemOffset = selectedItem?.offsetTop ?? 0;
+	let nextTop = triggerRect.top - itemOffset;
+	let scrollTop = 0;
+
+	const minTop = overflowPadding;
+	const maxTop = viewportHeight - constrainedHeight - overflowPadding;
+
+	if (nextTop < minTop) {
+		scrollTop = minTop - nextTop;
+		nextTop = minTop;
+	} else if (nextTop > maxTop) {
+		nextTop = Math.max(minTop, maxTop);
+	}
+
+	scroller.scrollTop = scrollTop;
+
+	if (selectedItem) {
+		const itemTop = selectedItem.offsetTop;
+		const itemBottom = itemTop + selectedItem.offsetHeight;
+		if (itemTop < scroller.scrollTop) {
+			scroller.scrollTop = itemTop;
+		} else if (itemBottom > scroller.scrollTop + constrainedHeight) {
+			scroller.scrollTop = itemBottom - constrainedHeight;
+		}
+	}
+
+	const positionerRect = positioner.getBoundingClientRect();
+	const currentY = parseFloat(positioner.style.getPropertyValue("--y") || "0") || 0;
+	const currentX = parseFloat(positioner.style.getPropertyValue("--x") || "0") || 0;
+
+	const deltaY = nextTop - positionerRect.top;
+	positioner.style.setProperty("--y", `${currentY + deltaY}px`);
+
+	const menuWidth = positionerRect.width || content.offsetWidth;
+	let nextLeft = positionerRect.left;
+	const minLeft = overflowPadding;
+	const maxLeft = viewportWidth - menuWidth - overflowPadding;
+	if (nextLeft < minLeft) {
+		nextLeft = minLeft;
+	} else if (nextLeft > maxLeft) {
+		nextLeft = Math.max(minLeft, maxLeft);
+	}
+	const deltaX = nextLeft - positionerRect.left;
+	if (deltaX !== 0) {
+		positioner.style.setProperty("--x", `${currentX + deltaX}px`);
+	}
+
+	return getSelectScrollState(scroller);
+}
+
+export function getSelectScrollState(scroller: HTMLElement): AlignSelectDropdownResult {
+	const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+	const scrollTop = scroller.scrollTop;
+	return {
+		canScrollUp: scrollTop > SCROLL_EDGE_TOLERANCE,
+		canScrollDown: scrollTop < maxScrollTop - SCROLL_EDGE_TOLERANCE,
+	};
+}
+
+/**
+ * Resolves the trigger that controls a select content element via `aria-controls`.
+ */
+export function getSelectTriggerForContent(content: HTMLElement): HTMLElement | null {
+	if (!content.id) return null;
+	return document.querySelector<HTMLElement>(
+		`[data-scope="select"][data-part="trigger"][aria-controls="${CSS.escape(content.id)}"]`,
+	);
+}
+
+export function getSelectedSelectItem(content: HTMLElement): HTMLElement | null {
+	return content.querySelector<HTMLElement>('[data-part="item"][data-state="checked"]');
+}
+
+export function getSelectContentScroller(content: HTMLElement): HTMLElement {
+	return getSelectScroller(content);
+}
+
+export const SELECT_LINEAR_POSITIONING = {
+	placement: "bottom-start" as const,
+	gutter: 0,
+	overlap: true,
+	flip: false,
+	slide: true,
+	fitViewport: true,
+	overflowPadding: DEFAULT_OVERFLOW_PADDING,
+};

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -60,7 +60,8 @@ function isSelectedItemInView(scroller: HTMLElement, selectedItem: HTMLElement):
 	const bottom = top + selectedItem.offsetHeight;
 	const viewTop = scroller.scrollTop;
 	const viewBottom = viewTop + scroller.clientHeight;
-	return top >= viewTop - SCROLL_EDGE_TOLERANCE && bottom <= viewBottom + SCROLL_EDGE_TOLERANCE;
+	// Partially visible is enough to consider alignment successful.
+	return bottom > viewTop + SCROLL_EDGE_TOLERANCE && top < viewBottom - SCROLL_EDGE_TOLERANCE;
 }
 
 /**

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -55,6 +55,14 @@ function isAlignmentReady(
 	return true;
 }
 
+function isSelectedItemInView(scroller: HTMLElement, selectedItem: HTMLElement): boolean {
+	const top = selectedItem.offsetTop;
+	const bottom = top + selectedItem.offsetHeight;
+	const viewTop = scroller.scrollTop;
+	const viewBottom = viewTop + scroller.clientHeight;
+	return top >= viewTop - SCROLL_EDGE_TOLERANCE && bottom <= viewBottom + SCROLL_EDGE_TOLERANCE;
+}
+
 /**
  * Positions a select dropdown Linear-style: the menu overlays the trigger and
  * the selected item is vertically aligned with it, clamped to the viewport.
@@ -72,10 +80,21 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 
 	const scroller = getSelectScroller(content);
 	const ready = isAlignmentReady(content, trigger, selectedItem, hasValue);
-	const alreadyAligned = content.dataset.linearAligned === "true";
+	let alreadyAligned = content.dataset.linearAligned === "true";
 
 	if (!ready && !alreadyAligned) {
 		return getSelectScrollState(scroller);
+	}
+
+	// Unlock if layout finished later and the selected row is no longer in view.
+	if (
+		alreadyAligned &&
+		selectedItem &&
+		scroller.clientHeight > 0 &&
+		!isSelectedItemInView(scroller, selectedItem)
+	) {
+		alreadyAligned = false;
+		content.removeAttribute("data-linear-aligned");
 	}
 
 	const triggerRect = trigger.getBoundingClientRect();
@@ -131,22 +150,32 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 		}
 
 		const deltaY = nextTop - positionerRect.top;
-		positioner.style.setProperty("--y", `${currentY + deltaY}px`);
-		content.dataset.linearAligned = "true";
+		const nextY = currentY + deltaY;
+		positioner.style.setProperty("--y", `${nextY}px`);
+		content.dataset.linearY = `${nextY}px`;
+
+		if (!selectedItem || isSelectedItemInView(scroller, selectedItem)) {
+			content.dataset.linearAligned = "true";
+		}
+	} else if (content.dataset.linearY) {
+		positioner.style.setProperty("--y", content.dataset.linearY);
 	}
 
-	const menuWidth = positionerRect.width || content.offsetWidth;
 	let nextLeft = positionerRect.left;
 	const minLeft = overflowPadding;
-	const maxLeft = viewportWidth - menuWidth - overflowPadding;
+	const maxLeft = viewportWidth - (positionerRect.width || content.offsetWidth) - overflowPadding;
 	if (nextLeft < minLeft) {
 		nextLeft = minLeft;
 	} else if (nextLeft > maxLeft) {
 		nextLeft = Math.max(minLeft, maxLeft);
 	}
 	const deltaX = nextLeft - positionerRect.left;
-	if (deltaX !== 0) {
-		positioner.style.setProperty("--x", `${currentX + deltaX}px`);
+	if (!alreadyAligned || deltaX !== 0) {
+		const nextX = currentX + deltaX;
+		positioner.style.setProperty("--x", `${nextX}px`);
+		content.dataset.linearX = `${nextX}px`;
+	} else if (content.dataset.linearX) {
+		positioner.style.setProperty("--x", content.dataset.linearX);
 	}
 
 	const state = getSelectScrollState(scroller);
@@ -162,6 +191,8 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 /** Clears one-shot alignment state so the next open can re-align to the selection. */
 export function resetSelectLinearAlignment(content: HTMLElement | null | undefined) {
 	content?.removeAttribute("data-linear-aligned");
+	content?.removeAttribute("data-linear-y");
+	content?.removeAttribute("data-linear-x");
 }
 
 export function getSelectScrollState(scroller: HTMLElement): AlignSelectDropdownResult {

--- a/packages/core/src/components/select/align-select.ts
+++ b/packages/core/src/components/select/align-select.ts
@@ -73,8 +73,9 @@ export function alignSelectDropdown(options: AlignSelectDropdownOptions): AlignS
 
 	content.style.height = "auto";
 	content.style.maxHeight = "none";
+	scroller.style.height = "auto";
 	scroller.style.maxHeight = "none";
-	const fullHeight = scroller.scrollHeight;
+	const fullHeight = Math.max(scroller.scrollHeight, scroller.offsetHeight);
 
 	const constrainedHeight = Math.min(
 		fullHeight,

--- a/packages/core/src/components/select/create-linear-positioning.ts
+++ b/packages/core/src/components/select/create-linear-positioning.ts
@@ -1,0 +1,73 @@
+import {
+	alignSelectDropdown,
+	getSelectedSelectItem,
+	getSelectTriggerForContent,
+	SELECT_LINEAR_POSITIONING,
+} from "./align-select";
+
+export interface SelectPositioningUpdateDetails {
+	updatePosition: () => Promise<void>;
+	floatingElement: HTMLElement | null;
+}
+
+/**
+ * Minimal positioning shape compatible with Ark/Zag `PositioningOptions`.
+ * Kept loose so core stays free of `@zag-js/*` dependencies.
+ */
+export type SelectPositioningOptions = {
+	placement?: "bottom-start" | "bottom" | "bottom-end" | "top-start" | "top" | "top-end" | (string & {});
+	gutter?: number;
+	overlap?: boolean;
+	flip?: boolean | string[];
+	slide?: boolean;
+	fitViewport?: boolean;
+	sameWidth?: boolean;
+	overflowPadding?: number;
+	updatePosition?: (details: SelectPositioningUpdateDetails) => void | Promise<void>;
+};
+
+export interface CreateLinearSelectPositioningOptions<T extends SelectPositioningOptions = SelectPositioningOptions> {
+	maxHeight?: number;
+	positioning?: T;
+}
+
+/**
+ * Builds Ark/Zag positioning options that overlay the menu on the trigger and
+ * align the selected item (Linear-style), while chaining any user `updatePosition`.
+ */
+export function createLinearSelectPositioning<T extends SelectPositioningOptions = SelectPositioningOptions>(
+	options: CreateLinearSelectPositioningOptions<T> = {},
+): T {
+	const userPositioning = options.positioning;
+
+	return {
+		...SELECT_LINEAR_POSITIONING,
+		...userPositioning,
+		updatePosition: async (details: SelectPositioningUpdateDetails) => {
+			if (userPositioning?.updatePosition) {
+				await userPositioning.updatePosition(details);
+			} else {
+				await details.updatePosition();
+			}
+
+			const positioner = details.floatingElement;
+			if (!positioner) return;
+
+			const content = positioner.querySelector<HTMLElement>('[data-part="content"]');
+			if (!content || content.hidden) return;
+
+			const trigger = getSelectTriggerForContent(content);
+			if (!trigger) return;
+
+			alignSelectDropdown({
+				positioner,
+				content,
+				trigger,
+				selectedItem: getSelectedSelectItem(content),
+				overflowPadding:
+					userPositioning?.overflowPadding ?? SELECT_LINEAR_POSITIONING.overflowPadding,
+				maxHeight: options.maxHeight,
+			});
+		},
+	} as T;
+}

--- a/packages/core/src/components/select/create-linear-positioning.ts
+++ b/packages/core/src/components/select/create-linear-positioning.ts
@@ -28,6 +28,8 @@ export type SelectPositioningOptions = {
 
 export interface CreateLinearSelectPositioningOptions<T extends SelectPositioningOptions = SelectPositioningOptions> {
 	maxHeight?: number;
+	/** Optional resolver for whether the select currently has a value. */
+	hasValue?: () => boolean;
 	positioning?: T;
 }
 
@@ -70,6 +72,7 @@ export function createLinearSelectPositioning<T extends SelectPositioningOptions
 					content,
 					trigger,
 					selectedItem: getSelectedSelectItem(content),
+					hasValue: options.hasValue?.(),
 					overflowPadding,
 					maxHeight: options.maxHeight,
 				});

--- a/packages/core/src/components/select/create-linear-positioning.ts
+++ b/packages/core/src/components/select/create-linear-positioning.ts
@@ -31,6 +31,8 @@ export interface CreateLinearSelectPositioningOptions<T extends SelectPositionin
 	positioning?: T;
 }
 
+const MAX_ALIGN_RETRIES = 12;
+
 /**
  * Builds Ark/Zag positioning options that overlay the menu on the trigger and
  * align the selected item (Linear-style), while chaining any user `updatePosition`.
@@ -59,15 +61,39 @@ export function createLinearSelectPositioning<T extends SelectPositioningOptions
 			const trigger = getSelectTriggerForContent(content);
 			if (!trigger) return;
 
-			alignSelectDropdown({
-				positioner,
-				content,
-				trigger,
-				selectedItem: getSelectedSelectItem(content),
-				overflowPadding:
-					userPositioning?.overflowPadding ?? SELECT_LINEAR_POSITIONING.overflowPadding,
-				maxHeight: options.maxHeight,
-			});
+			const overflowPadding =
+				userPositioning?.overflowPadding ?? SELECT_LINEAR_POSITIONING.overflowPadding;
+
+			const runAlign = () => {
+				alignSelectDropdown({
+					positioner,
+					content,
+					trigger,
+					selectedItem: getSelectedSelectItem(content),
+					overflowPadding,
+					maxHeight: options.maxHeight,
+				});
+			};
+
+			runAlign();
+
+			// First paint can run before items/checked state exist; retry briefly.
+			if (content.dataset.linearAligned !== "true") {
+				let retries = 0;
+				const retry = () => {
+					if (content.dataset.linearAligned === "true" || content.hidden) return;
+					if (retries++ >= MAX_ALIGN_RETRIES) return;
+					requestAnimationFrame(() => {
+						void details.updatePosition().then(() => {
+							runAlign();
+							if (content.dataset.linearAligned !== "true") {
+								retry();
+							}
+						});
+					});
+				};
+				retry();
+			}
 		},
 	} as T;
 }

--- a/packages/core/src/components/select/index.ts
+++ b/packages/core/src/components/select/index.ts
@@ -1,1 +1,4 @@
 export * from "./select";
+export * from "./align-select";
+export * from "./create-linear-positioning";
+export * from "./scroll-carets";

--- a/packages/core/src/components/select/scroll-carets.ts
+++ b/packages/core/src/components/select/scroll-carets.ts
@@ -1,7 +1,7 @@
 import type { AlignSelectDropdownResult } from "./align-select";
 import { getSelectScrollState } from "./align-select";
 
-const DEFAULT_SCROLL_STEP_PX = 6;
+const DEFAULT_SCROLL_STEP_PX = 18;
 const DEFAULT_SCROLL_INTERVAL_MS = 16;
 
 export interface StartSelectCaretAutoScrollOptions {

--- a/packages/core/src/components/select/scroll-carets.ts
+++ b/packages/core/src/components/select/scroll-carets.ts
@@ -1,0 +1,52 @@
+import type { AlignSelectDropdownResult } from "./align-select";
+import { getSelectScrollState } from "./align-select";
+
+const DEFAULT_SCROLL_STEP_PX = 6;
+const DEFAULT_SCROLL_INTERVAL_MS = 16;
+
+export interface StartSelectCaretAutoScrollOptions {
+	scroller: HTMLElement;
+	direction: "up" | "down";
+	/** Pixels scrolled per tick. @default 6 */
+	step?: number;
+	/** Interval between ticks in ms. @default 16 */
+	intervalMs?: number;
+	onScroll?: (state: AlignSelectDropdownResult) => void;
+}
+
+/**
+ * Starts continuous scrolling while a scroll caret is hovered.
+ * Returns a stop function (also stops automatically at scroll edges).
+ */
+export function startSelectCaretAutoScroll(options: StartSelectCaretAutoScrollOptions): () => void {
+	const {
+		scroller,
+		direction,
+		step = DEFAULT_SCROLL_STEP_PX,
+		intervalMs = DEFAULT_SCROLL_INTERVAL_MS,
+		onScroll,
+	} = options;
+
+	const delta = direction === "up" ? -step : step;
+
+	const tick = () => {
+		const maxScrollTop = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+		const next = Math.min(maxScrollTop, Math.max(0, scroller.scrollTop + delta));
+		scroller.scrollTop = next;
+		const state = getSelectScrollState(scroller);
+		onScroll?.(state);
+
+		const atEdge = direction === "up" ? !state.canScrollUp : !state.canScrollDown;
+		if (atEdge) {
+			stop();
+		}
+	};
+
+	const id = window.setInterval(tick, intervalMs);
+
+	function stop() {
+		window.clearInterval(id);
+	}
+
+	return stop;
+}

--- a/packages/core/src/components/select/select.css
+++ b/packages/core/src/components/select/select.css
@@ -21,7 +21,7 @@
 
 	[data-scope="combobox"][data-part="content"],
 	[data-scope="select"][data-part="content"] {
-		@apply bg-popover text-popover-foreground relative z-50 flex flex-col overflow-hidden rounded-md border shadow-md w-full min-w-(--reference-width) origin-(--transform-origin);
+		@apply bg-popover text-popover-foreground relative z-50 overflow-hidden rounded-md border shadow-md w-full min-w-(--reference-width) origin-(--transform-origin);
 
 		&[data-state="open"] {
 			@apply animate-in fade-in-0 zoom-in-95;
@@ -37,8 +37,9 @@
 	}
 
 	[data-component="select"][data-slot="list"] {
-		@apply min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain py-1;
+		@apply overflow-x-hidden overflow-y-auto overscroll-contain py-1;
 		scrollbar-width: none;
+		max-height: inherit;
 
 		&::-webkit-scrollbar {
 			display: none;

--- a/packages/core/src/components/select/select.css
+++ b/packages/core/src/components/select/select.css
@@ -21,7 +21,7 @@
 
 	[data-scope="combobox"][data-part="content"],
 	[data-scope="select"][data-part="content"] {
-		@apply bg-popover text-popover-foreground relative z-50 max-h-(--available-height) overflow-x-hidden overflow-y-auto rounded-md border shadow-md w-full scroll-my-1 min-w-(--reference-width) origin-(--transform-origin);
+		@apply bg-popover text-popover-foreground relative z-50 flex flex-col overflow-hidden rounded-md border shadow-md w-full min-w-(--reference-width) origin-(--transform-origin);
 
 		&[data-state="open"] {
 			@apply animate-in fade-in-0 zoom-in-95;
@@ -30,26 +30,39 @@
 		&[data-state="closed"] {
 			@apply animate-out fade-out-0 zoom-out-95;
 		}
-
-		&[data-placement*="bottom"] {
-			@apply slide-in-from-top-2 translate-y-1;
-		}
-
-		&[data-placement*="top"] {
-			@apply slide-in-from-bottom-2 translate-y-1;
-		}
-
-		&[data-placement*="left"] {
-			@apply slide-in-from-right-2 translate-x-1;
-		}
-
-		&[data-placement*="right"] {
-			@apply slide-in-from-left-2 translate-x-1;
-		}
 	}
 
 	[data-scope="combobox"][data-part="input"] {
 		@apply w-full outline-none text-sm;
+	}
+
+	[data-component="select"][data-slot="list"] {
+		@apply min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain py-1;
+		scrollbar-width: none;
+
+		&::-webkit-scrollbar {
+			display: none;
+		}
+	}
+
+	[data-component="select"][data-slot="scroll-caret"] {
+		@apply absolute inset-x-0 z-10 flex h-6 items-center justify-center text-muted-foreground pointer-events-none opacity-0 transition-opacity;
+
+		&[data-visible] {
+			@apply pointer-events-auto opacity-100;
+		}
+
+		&[data-direction="up"] {
+			@apply top-0 bg-gradient-to-b from-popover via-popover/90 to-transparent;
+		}
+
+		&[data-direction="down"] {
+			@apply bottom-0 bg-gradient-to-t from-popover via-popover/90 to-transparent;
+		}
+
+		& svg {
+			@apply size-3.5;
+		}
 	}
 
 	[data-scope="combobox"][data-part="item-group"],

--- a/packages/core/src/components/select/select.css
+++ b/packages/core/src/components/select/select.css
@@ -46,22 +46,22 @@
 	}
 
 	[data-component="select"][data-slot="scroll-caret"] {
-		@apply absolute inset-x-0 z-10 flex h-6 items-center justify-center text-muted-foreground pointer-events-none opacity-0 transition-opacity;
+		@apply absolute inset-x-0 z-20 flex h-7 items-center justify-center text-muted-foreground pointer-events-none opacity-0 transition-opacity cursor-default;
 
 		&[data-visible] {
 			@apply pointer-events-auto opacity-100;
 		}
 
 		&[data-direction="up"] {
-			@apply top-0 bg-gradient-to-b from-popover via-popover/90 to-transparent;
+			@apply top-0 bg-gradient-to-b from-popover from-40% via-popover/90 to-transparent;
 		}
 
 		&[data-direction="down"] {
-			@apply bottom-0 bg-gradient-to-t from-popover via-popover/90 to-transparent;
+			@apply bottom-0 bg-gradient-to-t from-popover from-40% via-popover/90 to-transparent;
 		}
 
 		& svg {
-			@apply size-3.5;
+			@apply size-3.5 shrink-0;
 		}
 	}
 

--- a/packages/core/src/components/select/select.css
+++ b/packages/core/src/components/select/select.css
@@ -62,7 +62,7 @@
 		}
 
 		& svg {
-			@apply size-3.5 shrink-0;
+			@apply size-3.5 shrink-0 pointer-events-none;
 		}
 	}
 

--- a/packages/core/src/components/select/select.ts
+++ b/packages/core/src/components/select/select.ts
@@ -32,5 +32,6 @@ export interface SelectProps<T = unknown> extends FieldProps<T> {
 		indicator?: string;
 		valueText?: string;
 		itemText?: string;
+		scrollCaret?: string;
 	};
 }

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -103,6 +103,27 @@ export const LinearNearViewportEdge: Story = {
 	],
 };
 
+export const LinearOpenWithCarets: Story = {
+	...Default,
+	name: "Linear style (open with carets)",
+	args: {
+		...Default.args,
+		defaultValue: ["passionfruit"],
+		maxDropdownHeight: 200,
+		defaultOpen: true,
+		label: "Fruit",
+		hint: "Pre-opened near the top so scroll carets are visible",
+		portal: true,
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ padding: "12px 16px", display: "flex", justifyContent: "flex-end" }}>
+				<Story key="linear-open-carets" />
+			</div>
+		),
+	],
+};
+
 export const MaxDropdownHeight: Story = {
 	...Default,
 	args: {

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -58,11 +58,57 @@ export const Default: Story = {
 	},
 };
 
+export const LinearAlignedSelection: Story = {
+	...Default,
+	name: "Linear style (aligned selection)",
+	args: {
+		...Default.args,
+		defaultValue: ["mango"],
+		label: "First day of the week",
+		hint: "Used for date pickers",
+	},
+	decorators: [
+		(Story) => (
+			<div
+				style={{
+					minHeight: "70vh",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "flex-end",
+					padding: "2rem",
+				}}
+			>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const LinearNearViewportEdge: Story = {
+	...Default,
+	name: "Linear style (near top edge + carets)",
+	args: {
+		...Default.args,
+		defaultValue: ["passionfruit"],
+		maxDropdownHeight: 220,
+		label: "Fruit",
+		hint: "Open near the top of the viewport to see scroll carets",
+	},
+	decorators: [
+		(Story) => (
+			<div style={{ padding: "1rem", display: "flex", justifyContent: "flex-end" }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
 export const MaxDropdownHeight: Story = {
 	...Default,
 	args: {
 		...Default.args,
 		maxDropdownHeight: 150,
+		defaultValue: ["orange"],
 	},
 };
 

--- a/packages/react/src/components/select/Select.test.tsx
+++ b/packages/react/src/components/select/Select.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { createListCollection, Select, type SelectItem } from ".";
 
@@ -6,6 +7,14 @@ const collection = createListCollection<SelectItem<unknown>>({
 	items: [
 		{ value: "a", label: "Alpha" },
 		{ value: "b", label: "Beta" },
+		{ value: "c", label: "Charlie" },
+		{ value: "d", label: "Delta" },
+		{ value: "e", label: "Echo" },
+		{ value: "f", label: "Foxtrot" },
+		{ value: "g", label: "Golf" },
+		{ value: "h", label: "Hotel" },
+		{ value: "i", label: "India" },
+		{ value: "j", label: "Juliet" },
 	],
 });
 
@@ -40,5 +49,30 @@ describe("Select", () => {
 		);
 		expect(screen.getByTestId("sel2--trigger")).toHaveClass("slot-trigger");
 		expect(screen.getByTestId("sel2--value-text")).toHaveClass("slot-value");
+	});
+
+	it("renders scroll carets when the open menu is constrained", async () => {
+		const user = userEvent.setup();
+		render(
+			<div style={{ paddingTop: 8 }}>
+				<Select
+					testId="sel3"
+					label="Pick"
+					collection={collection}
+					placeholder="Choose"
+					portal={false}
+					defaultValue={["j"]}
+					maxDropdownHeight={120}
+					defaultOpen
+				/>
+			</div>,
+		);
+
+		expect(screen.getByTestId("sel3--content")).toBeInTheDocument();
+		expect(screen.getByTestId("sel3--scroll-caret-up")).toBeInTheDocument();
+		expect(screen.getByTestId("sel3--scroll-caret-down")).toBeInTheDocument();
+
+		// Close to ensure interactions still work
+		await user.keyboard("{Escape}");
 	});
 });

--- a/packages/react/src/components/select/Select.test.tsx
+++ b/packages/react/src/components/select/Select.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createListCollection, Select, type SelectItem } from ".";
 
 const collection = createListCollection<SelectItem<unknown>>({
@@ -72,7 +72,69 @@ describe("Select", () => {
 		expect(screen.getByTestId("sel3--scroll-caret-up")).toBeInTheDocument();
 		expect(screen.getByTestId("sel3--scroll-caret-down")).toBeInTheDocument();
 
-		// Close to ensure interactions still work
 		await user.keyboard("{Escape}");
+	});
+
+	it("aligns to a late selected value and shows an up scroll caret", async () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+		Object.defineProperty(document.documentElement, "clientWidth", {
+			configurable: true,
+			value: 1200,
+		});
+
+		render(
+			<div style={{ paddingTop: 24 }}>
+				<Select
+					testId="sel4"
+					label="Pick"
+					collection={collection}
+					placeholder="Choose"
+					portal={false}
+					defaultValue={["j"]}
+					maxDropdownHeight={120}
+					defaultOpen
+				/>
+			</div>,
+		);
+
+		const list = await screen.findByTestId("sel4--content-list");
+		const selected = list.querySelector<HTMLElement>('[data-state="checked"]');
+		expect(selected).toBeTruthy();
+		expect(selected).toHaveTextContent("Juliet");
+
+		// happy-dom often reports offsetTop as 0; stub layout for the selected row.
+		const items = [...list.querySelectorAll<HTMLElement>('[data-part="item"]')];
+		items.forEach((item, index) => {
+			Object.defineProperty(item, "offsetTop", { configurable: true, value: index * 32 });
+			Object.defineProperty(item, "offsetHeight", { configurable: true, value: 32 });
+		});
+		Object.defineProperty(list, "scrollHeight", { configurable: true, value: items.length * 32 });
+		Object.defineProperty(list, "clientHeight", { configurable: true, value: 120 });
+
+		const content = screen.getByTestId("sel4--content");
+		content.removeAttribute("data-linear-aligned");
+
+		const { alignSelectDropdown, getSelectTriggerForContent } = await import(
+			"@temporal-ui/core/select"
+		);
+		const positioner = screen.getByTestId("sel4--positioner");
+		const trigger = getSelectTriggerForContent(content);
+		expect(trigger).toBeTruthy();
+
+		alignSelectDropdown({
+			positioner,
+			content,
+			trigger: trigger!,
+			selectedItem: selected,
+			hasValue: true,
+			maxHeight: 120,
+		});
+
+		expect(list.scrollTop).toBeGreaterThan(0);
+		const { getSelectScrollState } = await import("@temporal-ui/core/select");
+		expect(getSelectScrollState(list).canScrollUp).toBe(true);
 	});
 });

--- a/packages/react/src/components/select/Select.test.tsx
+++ b/packages/react/src/components/select/Select.test.tsx
@@ -137,4 +137,43 @@ describe("Select", () => {
 		const { getSelectScrollState } = await import("@temporal-ui/core/select");
 		expect(getSelectScrollState(list).canScrollUp).toBe(true);
 	});
+
+	it("auto-scrolls the list while hovering a scroll caret", async () => {
+		const user = userEvent.setup();
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		render(
+			<Select
+				testId="sel5"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				defaultValue={["a"]}
+				maxDropdownHeight={120}
+				defaultOpen
+			/>,
+		);
+
+		const list = await screen.findByTestId("sel5--content-list");
+		const items = [...list.querySelectorAll<HTMLElement>('[data-part="item"]')];
+		items.forEach((item, index) => {
+			Object.defineProperty(item, "offsetTop", { configurable: true, value: index * 32 });
+			Object.defineProperty(item, "offsetHeight", { configurable: true, value: 32 });
+		});
+		Object.defineProperty(list, "scrollHeight", { configurable: true, value: items.length * 32 });
+		Object.defineProperty(list, "clientHeight", { configurable: true, value: 120 });
+		list.scrollTop = 0;
+
+		const caretDown = screen.getByTestId("sel5--scroll-caret-down");
+		caretDown.setAttribute("data-visible", "");
+		await user.hover(caretDown);
+
+		await vi.waitFor(() => {
+			expect(list.scrollTop).toBeGreaterThan(0);
+		});
+	});
 });

--- a/packages/react/src/components/select/Select.tsx
+++ b/packages/react/src/components/select/Select.tsx
@@ -1,6 +1,9 @@
 import { Select as ArkSelect, useSelect, type CollectionItem } from "@ark-ui/react/select";
 import { Portal } from "@ark-ui/react/portal";
-import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import {
+	createLinearSelectPositioning,
+	type SelectProps as CoreSelectProps,
+} from "@temporal-ui/core/select";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { Field } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
@@ -26,6 +29,7 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		className,
 		maxDropdownHeight,
 		deselectable,
+		positioning,
 		...rootProps
 	} = props;
 
@@ -35,6 +39,10 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		invalid: !!error,
 		required,
 		readOnly,
+		positioning: createLinearSelectPositioning({
+			maxHeight: maxDropdownHeight,
+			positioning,
+		}),
 	});
 
 	const tid = testId(testIdProp);

--- a/packages/react/src/components/select/Select.tsx
+++ b/packages/react/src/components/select/Select.tsx
@@ -9,6 +9,7 @@ import { Field } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-react";
+import { useRef } from "react";
 
 export interface SelectProps<D extends CollectionItem = never>
 	extends CoreSelectProps<React.ReactNode>, ArkSelect.RootProps<SelectItem<D>> {}
@@ -33,6 +34,7 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		...rootProps
 	} = props;
 
+	const selectRef = useRef<{ value: string[] } | null>(null);
 	const select = useSelect({
 		...rootProps,
 		disabled,
@@ -41,9 +43,11 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		readOnly,
 		positioning: createLinearSelectPositioning({
 			maxHeight: maxDropdownHeight,
+			hasValue: () => (selectRef.current?.value.length ?? 0) > 0,
 			positioning,
 		}),
 	});
+	selectRef.current = select;
 
 	const tid = testId(testIdProp);
 

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -168,6 +168,8 @@ export function SelectContent(props: SelectContentProps) {
 					data-testid={tid("--scroll-caret-up")}
 					onPointerEnter={() => startCaretScroll("up")}
 					onPointerLeave={stopCaretScroll}
+					onMouseEnter={() => startCaretScroll("up")}
+					onMouseLeave={stopCaretScroll}
 				>
 					<ChevronUp />
 				</div>

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -141,7 +141,6 @@ export function SelectContent(props: SelectContentProps) {
 					data-component="select"
 					data-slot="list"
 					data-testid={tid("--content-list")}
-					style={{ maxHeight: "100%", height: "100%" }}
 					onScroll={syncScrollState}
 				>
 					{context.collection.group().map(([type, group]) => (

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -1,13 +1,16 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/react/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
 import {
+	alignSelectDropdown,
+	getSelectedSelectItem,
 	getSelectScrollState,
+	getSelectTriggerForContent,
 	resetSelectLinearAlignment,
 	startSelectCaretAutoScroll,
 	type AlignSelectDropdownResult,
 } from "@temporal-ui/core/select";
 import { CheckIcon, ChevronDown, ChevronUp } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 export type SelectItem<D = unknown> = CoreSelectItem<D, React.ReactNode>;
 
@@ -48,7 +51,25 @@ export function SelectContent(props: SelectContentProps) {
 		applyScrollState(getSelectScrollState(list));
 	}, [applyScrollState]);
 
-	useEffect(() => {
+	const runLinearAlign = useCallback(() => {
+		const content = contentRef.current;
+		if (!content || content.hidden) return false;
+		const positioner = content.closest<HTMLElement>('[data-part="positioner"]');
+		const trigger = getSelectTriggerForContent(content);
+		if (!positioner || !trigger) return false;
+
+		const state = alignSelectDropdown({
+			positioner,
+			content,
+			trigger,
+			selectedItem: getSelectedSelectItem(content),
+			maxHeight,
+		});
+		applyScrollState(state);
+		return content.dataset.linearAligned === "true";
+	}, [applyScrollState, maxHeight]);
+
+	useLayoutEffect(() => {
 		if (!context.open) {
 			setCanScrollUp(false);
 			setCanScrollDown(false);
@@ -58,18 +79,26 @@ export function SelectContent(props: SelectContentProps) {
 			return;
 		}
 
-		const frame = requestAnimationFrame(syncScrollState);
-		const poll = window.setInterval(syncScrollState, 50);
-		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 400);
+		// Clear any premature lock from floating-ui's first paint, then align.
+		resetSelectLinearAlignment(contentRef.current);
+
+		let retries = 0;
+		let frame = 0;
+		const tryAlign = () => {
+			if (runLinearAlign() || retries++ >= 16) {
+				syncScrollState();
+				return;
+			}
+			frame = requestAnimationFrame(tryAlign);
+		};
+		frame = requestAnimationFrame(tryAlign);
 
 		return () => {
 			cancelAnimationFrame(frame);
-			window.clearInterval(poll);
-			window.clearTimeout(stopPoll);
 			stopAutoScrollRef.current?.();
 			stopAutoScrollRef.current = null;
 		};
-	}, [context.open, context.value, syncScrollState]);
+	}, [context.open, context.value, runLinearAlign, syncScrollState]);
 
 	useEffect(() => {
 		const content = contentRef.current;

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -86,16 +86,21 @@ export function SelectContent(props: SelectContentProps) {
 		let retries = 0;
 		let frame = 0;
 		const tryAlign = () => {
-			if (runLinearAlign() || retries++ >= 16) {
-				syncScrollState();
+			const aligned = runLinearAlign();
+			syncScrollState();
+			if (aligned || retries++ >= 24) {
 				return;
 			}
 			frame = requestAnimationFrame(tryAlign);
 		};
 		frame = requestAnimationFrame(tryAlign);
+		const poll = window.setInterval(syncScrollState, 50);
+		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 1000);
 
 		return () => {
 			cancelAnimationFrame(frame);
+			window.clearInterval(poll);
+			window.clearTimeout(stopPoll);
 			stopAutoScrollRef.current?.();
 			stopAutoScrollRef.current = null;
 		};

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -63,11 +63,12 @@ export function SelectContent(props: SelectContentProps) {
 			content,
 			trigger,
 			selectedItem: getSelectedSelectItem(content),
+			hasValue: (context.value?.length ?? 0) > 0,
 			maxHeight,
 		});
 		applyScrollState(state);
 		return content.dataset.linearAligned === "true";
-	}, [applyScrollState, maxHeight]);
+	}, [applyScrollState, context.value, maxHeight]);
 
 	useLayoutEffect(() => {
 		if (!context.open) {

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -1,6 +1,11 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/react/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
-import { getSelectScrollState, startSelectCaretAutoScroll } from "@temporal-ui/core/select";
+import {
+	getSelectScrollState,
+	resetSelectLinearAlignment,
+	startSelectCaretAutoScroll,
+	type AlignSelectDropdownResult,
+} from "@temporal-ui/core/select";
 import { CheckIcon, ChevronDown, ChevronUp } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -26,18 +31,22 @@ export interface SelectContentProps {
 export function SelectContent(props: SelectContentProps) {
 	const { tid, maxHeight = 500, classes } = props;
 	const context = useSelectContext();
+	const contentRef = useRef<HTMLDivElement>(null);
 	const listRef = useRef<HTMLDivElement>(null);
 	const stopAutoScrollRef = useRef<(() => void) | null>(null);
 	const [canScrollUp, setCanScrollUp] = useState(false);
 	const [canScrollDown, setCanScrollDown] = useState(false);
 
-	const syncScrollState = useCallback(() => {
-		const list = listRef.current;
-		if (!list) return;
-		const state = getSelectScrollState(list);
+	const applyScrollState = useCallback((state: AlignSelectDropdownResult) => {
 		setCanScrollUp(state.canScrollUp);
 		setCanScrollDown(state.canScrollDown);
 	}, []);
+
+	const syncScrollState = useCallback(() => {
+		const list = listRef.current;
+		if (!list) return;
+		applyScrollState(getSelectScrollState(list));
+	}, [applyScrollState]);
 
 	useEffect(() => {
 		if (!context.open) {
@@ -45,35 +54,50 @@ export function SelectContent(props: SelectContentProps) {
 			setCanScrollDown(false);
 			stopAutoScrollRef.current?.();
 			stopAutoScrollRef.current = null;
+			resetSelectLinearAlignment(contentRef.current);
 			return;
 		}
 
-		const frame = requestAnimationFrame(() => {
-			syncScrollState();
-		});
+		const frame = requestAnimationFrame(syncScrollState);
+		const poll = window.setInterval(syncScrollState, 50);
+		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 400);
 
 		return () => {
 			cancelAnimationFrame(frame);
+			window.clearInterval(poll);
+			window.clearTimeout(stopPoll);
 			stopAutoScrollRef.current?.();
 			stopAutoScrollRef.current = null;
 		};
 	}, [context.open, context.value, syncScrollState]);
 
 	useEffect(() => {
+		const content = contentRef.current;
 		const list = listRef.current;
-		if (!list || !context.open) return;
+		if (!content || !list || !context.open) return;
+
+		const onAligned = (event: Event) => {
+			const detail = (event as CustomEvent<AlignSelectDropdownResult>).detail;
+			if (detail) {
+				applyScrollState(detail);
+			} else {
+				syncScrollState();
+			}
+		};
 
 		const observer = new ResizeObserver(() => {
 			syncScrollState();
 		});
 		observer.observe(list);
+		content.addEventListener("temporal-ui:select-aligned", onAligned);
 		list.addEventListener("scroll", syncScrollState, { passive: true });
 
 		return () => {
 			observer.disconnect();
+			content.removeEventListener("temporal-ui:select-aligned", onAligned);
 			list.removeEventListener("scroll", syncScrollState);
 		};
-	}, [context.open, syncScrollState]);
+	}, [context.open, applyScrollState, syncScrollState]);
 
 	const startCaretScroll = (direction: "up" | "down") => {
 		stopAutoScrollRef.current?.();
@@ -82,10 +106,7 @@ export function SelectContent(props: SelectContentProps) {
 		stopAutoScrollRef.current = startSelectCaretAutoScroll({
 			scroller: list,
 			direction,
-			onScroll: (state) => {
-				setCanScrollUp(state.canScrollUp);
-				setCanScrollDown(state.canScrollDown);
-			},
+			onScroll: applyScrollState,
 		});
 	};
 
@@ -97,6 +118,7 @@ export function SelectContent(props: SelectContentProps) {
 	return (
 		<ArkSelect.Positioner className={classes?.positioner} data-testid={tid("--positioner")}>
 			<ArkSelect.Content
+				ref={contentRef}
 				className={classes?.content}
 				data-testid={tid("--content")}
 				style={{ maxHeight: `${maxHeight}px` }}
@@ -109,8 +131,8 @@ export function SelectContent(props: SelectContentProps) {
 					data-direction="up"
 					data-visible={canScrollUp ? "" : undefined}
 					data-testid={tid("--scroll-caret-up")}
-					onMouseEnter={() => startCaretScroll("up")}
-					onMouseLeave={stopCaretScroll}
+					onPointerEnter={() => startCaretScroll("up")}
+					onPointerLeave={stopCaretScroll}
 				>
 					<ChevronUp />
 				</div>
@@ -169,8 +191,8 @@ export function SelectContent(props: SelectContentProps) {
 					data-direction="down"
 					data-visible={canScrollDown ? "" : undefined}
 					data-testid={tid("--scroll-caret-down")}
-					onMouseEnter={() => startCaretScroll("down")}
-					onMouseLeave={stopCaretScroll}
+					onPointerEnter={() => startCaretScroll("down")}
+					onPointerLeave={stopCaretScroll}
 				>
 					<ChevronDown />
 				</div>

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -150,6 +150,13 @@ export function SelectContent(props: SelectContentProps) {
 		stopAutoScrollRef.current = null;
 	};
 
+	const nudgeScroll = (direction: "up" | "down") => {
+		const list = listRef.current;
+		if (!list) return;
+		list.scrollTop += direction === "up" ? -40 : 40;
+		syncScrollState();
+	};
+
 	return (
 		<ArkSelect.Positioner className={classes?.positioner} data-testid={tid("--positioner")}>
 			<ArkSelect.Content
@@ -160,6 +167,7 @@ export function SelectContent(props: SelectContentProps) {
 			>
 				<div
 					aria-hidden
+					role="presentation"
 					className={classes?.scrollCaret}
 					data-component="select"
 					data-slot="scroll-caret"
@@ -170,6 +178,7 @@ export function SelectContent(props: SelectContentProps) {
 					onPointerLeave={stopCaretScroll}
 					onMouseEnter={() => startCaretScroll("up")}
 					onMouseLeave={stopCaretScroll}
+					onClick={() => nudgeScroll("up")}
 				>
 					<ChevronUp />
 				</div>
@@ -221,6 +230,7 @@ export function SelectContent(props: SelectContentProps) {
 				</div>
 				<div
 					aria-hidden
+					role="presentation"
 					className={classes?.scrollCaret}
 					data-component="select"
 					data-slot="scroll-caret"
@@ -229,6 +239,9 @@ export function SelectContent(props: SelectContentProps) {
 					data-testid={tid("--scroll-caret-down")}
 					onPointerEnter={() => startCaretScroll("down")}
 					onPointerLeave={stopCaretScroll}
+					onMouseEnter={() => startCaretScroll("down")}
+					onMouseLeave={stopCaretScroll}
+					onClick={() => nudgeScroll("down")}
 				>
 					<ChevronDown />
 				</div>

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -1,6 +1,8 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/react/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
-import { CheckIcon } from "lucide-react";
+import { getSelectScrollState, startSelectCaretAutoScroll } from "@temporal-ui/core/select";
+import { CheckIcon, ChevronDown, ChevronUp } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type SelectItem<D = unknown> = CoreSelectItem<D, React.ReactNode>;
 
@@ -17,12 +19,81 @@ export interface SelectContentProps {
 		positioner?: string;
 		scrollArea?: string;
 		input?: string;
+		scrollCaret?: string;
 	};
 }
 
 export function SelectContent(props: SelectContentProps) {
 	const { tid, maxHeight = 500, classes } = props;
 	const context = useSelectContext();
+	const listRef = useRef<HTMLDivElement>(null);
+	const stopAutoScrollRef = useRef<(() => void) | null>(null);
+	const [canScrollUp, setCanScrollUp] = useState(false);
+	const [canScrollDown, setCanScrollDown] = useState(false);
+
+	const syncScrollState = useCallback(() => {
+		const list = listRef.current;
+		if (!list) return;
+		const state = getSelectScrollState(list);
+		setCanScrollUp(state.canScrollUp);
+		setCanScrollDown(state.canScrollDown);
+	}, []);
+
+	useEffect(() => {
+		if (!context.open) {
+			setCanScrollUp(false);
+			setCanScrollDown(false);
+			stopAutoScrollRef.current?.();
+			stopAutoScrollRef.current = null;
+			return;
+		}
+
+		const frame = requestAnimationFrame(() => {
+			syncScrollState();
+		});
+
+		return () => {
+			cancelAnimationFrame(frame);
+			stopAutoScrollRef.current?.();
+			stopAutoScrollRef.current = null;
+		};
+	}, [context.open, context.value, syncScrollState]);
+
+	useEffect(() => {
+		const list = listRef.current;
+		if (!list || !context.open) return;
+
+		const observer = new ResizeObserver(() => {
+			syncScrollState();
+		});
+		observer.observe(list);
+		list.addEventListener("scroll", syncScrollState, { passive: true });
+
+		return () => {
+			observer.disconnect();
+			list.removeEventListener("scroll", syncScrollState);
+		};
+	}, [context.open, syncScrollState]);
+
+	const startCaretScroll = (direction: "up" | "down") => {
+		stopAutoScrollRef.current?.();
+		const list = listRef.current;
+		if (!list) return;
+		stopAutoScrollRef.current = startSelectCaretAutoScroll({
+			scroller: list,
+			direction,
+			onScroll: (state) => {
+				setCanScrollUp(state.canScrollUp);
+				setCanScrollDown(state.canScrollDown);
+			},
+		});
+	};
+
+	const stopCaretScroll = () => {
+		stopAutoScrollRef.current?.();
+		stopAutoScrollRef.current = null;
+	};
+
 	return (
 		<ArkSelect.Positioner className={classes?.positioner} data-testid={tid("--positioner")}>
 			<ArkSelect.Content
@@ -30,7 +101,27 @@ export function SelectContent(props: SelectContentProps) {
 				data-testid={tid("--content")}
 				style={{ maxHeight: `${maxHeight}px` }}
 			>
-				<div data-component="select" data-slot="list" data-testid={tid("--content-list")}>
+				<div
+					aria-hidden
+					className={classes?.scrollCaret}
+					data-component="select"
+					data-slot="scroll-caret"
+					data-direction="up"
+					data-visible={canScrollUp ? "" : undefined}
+					data-testid={tid("--scroll-caret-up")}
+					onMouseEnter={() => startCaretScroll("up")}
+					onMouseLeave={stopCaretScroll}
+				>
+					<ChevronUp />
+				</div>
+				<div
+					ref={listRef}
+					data-component="select"
+					data-slot="list"
+					data-testid={tid("--content-list")}
+					style={{ maxHeight: "100%", height: "100%" }}
+					onScroll={syncScrollState}
+				>
 					{context.collection.group().map(([type, group]) => (
 						<ArkSelect.ItemGroup
 							key={type}
@@ -69,6 +160,19 @@ export function SelectContent(props: SelectContentProps) {
 							))}
 						</ArkSelect.ItemGroup>
 					))}
+				</div>
+				<div
+					aria-hidden
+					className={classes?.scrollCaret}
+					data-component="select"
+					data-slot="scroll-caret"
+					data-direction="down"
+					data-visible={canScrollDown ? "" : undefined}
+					data-testid={tid("--scroll-caret-down")}
+					onMouseEnter={() => startCaretScroll("down")}
+					onMouseLeave={stopCaretScroll}
+				>
+					<ChevronDown />
 				</div>
 			</ArkSelect.Content>
 		</ArkSelect.Positioner>

--- a/packages/solid/src/components/select/Select.stories.tsx
+++ b/packages/solid/src/components/select/Select.stories.tsx
@@ -1,5 +1,6 @@
 import { Banana } from "lucide-solid";
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import type { JSX } from "solid-js";
 import { createListCollection } from ".";
 import { Select } from "./Select";
 
@@ -55,11 +56,57 @@ export const Default: Story = {
 	},
 };
 
+export const LinearAlignedSelection: Story = {
+	...Default,
+	name: "Linear style (aligned selection)",
+	args: {
+		...Default.args,
+		defaultValue: ["mango"],
+		label: "First day of the week",
+		hint: "Used for date pickers",
+	},
+	decorators: [
+		(Story: () => JSX.Element) => (
+			<div
+				style={{
+					"min-height": "70vh",
+					display: "flex",
+					"align-items": "center",
+					"justify-content": "flex-end",
+					padding: "2rem",
+				}}
+			>
+				<Story />
+			</div>
+		),
+	],
+};
+
+export const LinearNearViewportEdge: Story = {
+	...Default,
+	name: "Linear style (near top edge + carets)",
+	args: {
+		...Default.args,
+		defaultValue: ["passionfruit"],
+		maxDropdownHeight: 220,
+		label: "Fruit",
+		hint: "Open near the top of the viewport to see scroll carets",
+	},
+	decorators: [
+		(Story: () => JSX.Element) => (
+			<div style={{ padding: "1rem", display: "flex", "justify-content": "flex-end" }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
 export const MaxDropdownHeight: Story = {
 	...Default,
 	args: {
 		...Default.args,
 		maxDropdownHeight: 150,
+		defaultValue: ["orange"],
 	},
 };
 

--- a/packages/solid/src/components/select/Select.stories.tsx
+++ b/packages/solid/src/components/select/Select.stories.tsx
@@ -101,6 +101,27 @@ export const LinearNearViewportEdge: Story = {
 	],
 };
 
+export const LinearOpenWithCarets: Story = {
+	...Default,
+	name: "Linear style (open with carets)",
+	args: {
+		...Default.args,
+		defaultValue: ["passionfruit"],
+		maxDropdownHeight: 200,
+		defaultOpen: true,
+		label: "Fruit",
+		hint: "Pre-opened near the top so scroll carets are visible",
+		portal: true,
+	},
+	decorators: [
+		(Story: () => JSX.Element) => (
+			<div style={{ padding: "12px 16px", display: "flex", "justify-content": "flex-end" }}>
+				<Story />
+			</div>
+		),
+	],
+};
+
 export const MaxDropdownHeight: Story = {
 	...Default,
 	args: {

--- a/packages/solid/src/components/select/Select.tsx
+++ b/packages/solid/src/components/select/Select.tsx
@@ -1,9 +1,12 @@
 import { Select as ArkSelect, useSelect } from "@ark-ui/solid/select";
-import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import {
+	createLinearSelectPositioning,
+	type SelectProps as CoreSelectProps,
+} from "@temporal-ui/core/select";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-solid";
-import { mergeProps, Show, splitProps, type JSX } from "solid-js";
+import { createMemo, mergeProps, Show, splitProps, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { Field, fieldAttributes } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
@@ -22,11 +25,21 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 		"placeholder",
 	]);
 
+	const positioning = createMemo(() =>
+		createLinearSelectPositioning({
+			maxHeight: controlProps.maxDropdownHeight,
+			positioning: rootProps.positioning,
+		}),
+	);
+
 	const useSelectProps = mergeProps(rootProps, {
 		disabled: fieldProps.disabled,
 		invalid: !!fieldProps.error,
 		required: fieldProps.required,
 		readOnly: fieldProps.readOnly,
+		get positioning() {
+			return positioning();
+		},
 	});
 
 	const select = useSelect(useSelectProps);

--- a/packages/solid/src/components/select/Select.tsx
+++ b/packages/solid/src/components/select/Select.tsx
@@ -6,7 +6,7 @@ import {
 import { cx } from "@temporal-ui/core/utils/cx";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-solid";
-import { createMemo, mergeProps, Show, splitProps, type JSX } from "solid-js";
+import { mergeProps, Show, splitProps, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { Field, fieldAttributes } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
@@ -25,12 +25,7 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 		"placeholder",
 	]);
 
-	const positioning = createMemo(() =>
-		createLinearSelectPositioning({
-			maxHeight: controlProps.maxDropdownHeight,
-			positioning: rootProps.positioning,
-		}),
-	);
+	let selectApi: { value: string[] } | undefined;
 
 	const useSelectProps = mergeProps(rootProps, {
 		disabled: fieldProps.disabled,
@@ -38,11 +33,20 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 		required: fieldProps.required,
 		readOnly: fieldProps.readOnly,
 		get positioning() {
-			return positioning();
+			return createLinearSelectPositioning({
+				maxHeight: controlProps.maxDropdownHeight,
+				hasValue: () => (selectApi?.value.length ?? 0) > 0,
+				positioning: rootProps.positioning,
+			});
 		},
 	});
 
 	const select = useSelect(useSelectProps);
+	selectApi = {
+		get value() {
+			return select().value;
+		},
+	};
 
 	const tid = testId(fieldProps.testId);
 

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -71,6 +71,7 @@ export function SelectContent(_props: SelectContentProps) {
 			content,
 			trigger,
 			selectedItem: getSelectedSelectItem(content),
+			hasValue: (context().value?.length ?? 0) > 0,
 			maxHeight: props.maxHeight,
 		});
 		applyScrollState(state);

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -98,16 +98,21 @@ export function SelectContent(_props: SelectContentProps) {
 		let retries = 0;
 		let frame = 0;
 		const tryAlign = () => {
-			if (runLinearAlign() || retries++ >= 16) {
-				syncScrollState();
+			const aligned = runLinearAlign();
+			syncScrollState();
+			if (aligned || retries++ >= 24) {
 				return;
 			}
 			frame = requestAnimationFrame(tryAlign);
 		};
 		frame = requestAnimationFrame(tryAlign);
+		const poll = window.setInterval(syncScrollState, 50);
+		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 1000);
 
 		onCleanup(() => {
 			cancelAnimationFrame(frame);
+			window.clearInterval(poll);
+			window.clearTimeout(stopPoll);
 			stopAutoScroll?.();
 			stopAutoScroll = null;
 		});

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -1,7 +1,16 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/solid/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
-import { CheckIcon } from "lucide-solid";
-import { For, mergeProps, Show, type JSX } from "solid-js";
+import { getSelectScrollState, startSelectCaretAutoScroll } from "@temporal-ui/core/select";
+import { CheckIcon, ChevronDown, ChevronUp } from "lucide-solid";
+import {
+	createEffect,
+	createSignal,
+	For,
+	mergeProps,
+	onCleanup,
+	Show,
+	type JSX,
+} from "solid-js";
 
 export type SelectItem<D = unknown> = CoreSelectItem<D, JSX.Element>;
 
@@ -18,12 +27,87 @@ export interface SelectContentProps {
 		positioner?: string;
 		scrollArea?: string;
 		input?: string;
+		scrollCaret?: string;
 	};
 }
 
 export function SelectContent(_props: SelectContentProps) {
 	const props = mergeProps({ maxHeight: 500 }, _props);
 	const context = useSelectContext();
+	const [listEl, setListEl] = createSignal<HTMLDivElement | null>(null);
+	const [canScrollUp, setCanScrollUp] = createSignal(false);
+	const [canScrollDown, setCanScrollDown] = createSignal(false);
+	let stopAutoScroll: (() => void) | null = null;
+
+	const syncScrollState = () => {
+		const list = listEl();
+		if (!list) return;
+		const state = getSelectScrollState(list);
+		setCanScrollUp(state.canScrollUp);
+		setCanScrollDown(state.canScrollDown);
+	};
+
+	createEffect(() => {
+		const open = context().open;
+		const value = context().value;
+
+		if (!open) {
+			setCanScrollUp(false);
+			setCanScrollDown(false);
+			stopAutoScroll?.();
+			stopAutoScroll = null;
+			return;
+		}
+
+		// Depend on value so re-open with a new selection refreshes caret state.
+		void value;
+
+		const frame = requestAnimationFrame(() => {
+			syncScrollState();
+		});
+
+		onCleanup(() => {
+			cancelAnimationFrame(frame);
+			stopAutoScroll?.();
+			stopAutoScroll = null;
+		});
+	});
+
+	createEffect(() => {
+		const list = listEl();
+		const open = context().open;
+		if (!list || !open) return;
+
+		const observer = new ResizeObserver(() => {
+			syncScrollState();
+		});
+		observer.observe(list);
+		list.addEventListener("scroll", syncScrollState, { passive: true });
+
+		onCleanup(() => {
+			observer.disconnect();
+			list.removeEventListener("scroll", syncScrollState);
+		});
+	});
+
+	const startCaretScroll = (direction: "up" | "down") => {
+		stopAutoScroll?.();
+		const list = listEl();
+		if (!list) return;
+		stopAutoScroll = startSelectCaretAutoScroll({
+			scroller: list,
+			direction,
+			onScroll: (state) => {
+				setCanScrollUp(state.canScrollUp);
+				setCanScrollDown(state.canScrollDown);
+			},
+		});
+	};
+
+	const stopCaretScroll = () => {
+		stopAutoScroll?.();
+		stopAutoScroll = null;
+	};
 
 	return (
 		<ArkSelect.Positioner class={props.classes?.positioner} data-testid={props.tid("--positioner")}>
@@ -32,7 +116,27 @@ export function SelectContent(_props: SelectContentProps) {
 				data-testid={props.tid("--content")}
 				style={{ "max-height": `${props.maxHeight}px` }}
 			>
-				<div data-component="select" data-slot="list" data-testid={props.tid("--content-list")}>
+				<div
+					aria-hidden
+					class={props.classes?.scrollCaret}
+					data-component="select"
+					data-slot="scroll-caret"
+					data-direction="up"
+					data-visible={canScrollUp() ? "" : undefined}
+					data-testid={props.tid("--scroll-caret-up")}
+					onMouseEnter={() => startCaretScroll("up")}
+					onMouseLeave={stopCaretScroll}
+				>
+					<ChevronUp />
+				</div>
+				<div
+					ref={setListEl}
+					data-component="select"
+					data-slot="list"
+					data-testid={props.tid("--content-list")}
+					style={{ "max-height": "100%", height: "100%" }}
+					onScroll={syncScrollState}
+				>
 					<For each={context().collection.group()}>
 						{([type, group]) => (
 							<ArkSelect.ItemGroup
@@ -73,6 +177,19 @@ export function SelectContent(_props: SelectContentProps) {
 							</ArkSelect.ItemGroup>
 						)}
 					</For>
+				</div>
+				<div
+					aria-hidden
+					class={props.classes?.scrollCaret}
+					data-component="select"
+					data-slot="scroll-caret"
+					data-direction="down"
+					data-visible={canScrollDown() ? "" : undefined}
+					data-testid={props.tid("--scroll-caret-down")}
+					onMouseEnter={() => startCaretScroll("down")}
+					onMouseLeave={stopCaretScroll}
+				>
+					<ChevronDown />
 				</div>
 			</ArkSelect.Content>
 		</ArkSelect.Positioner>

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -163,6 +163,13 @@ export function SelectContent(_props: SelectContentProps) {
 		stopAutoScroll = null;
 	};
 
+	const nudgeScroll = (direction: "up" | "down") => {
+		const list = listEl();
+		if (!list) return;
+		list.scrollTop += direction === "up" ? -40 : 40;
+		syncScrollState();
+	};
+
 	return (
 		<ArkSelect.Positioner class={props.classes?.positioner} data-testid={props.tid("--positioner")}>
 			<ArkSelect.Content
@@ -173,6 +180,7 @@ export function SelectContent(_props: SelectContentProps) {
 			>
 				<div
 					aria-hidden
+					role="presentation"
 					class={props.classes?.scrollCaret}
 					data-component="select"
 					data-slot="scroll-caret"
@@ -181,6 +189,9 @@ export function SelectContent(_props: SelectContentProps) {
 					data-testid={props.tid("--scroll-caret-up")}
 					onPointerEnter={() => startCaretScroll("up")}
 					onPointerLeave={stopCaretScroll}
+					onMouseEnter={() => startCaretScroll("up")}
+					onMouseLeave={stopCaretScroll}
+					onClick={() => nudgeScroll("up")}
 				>
 					<ChevronUp />
 				</div>
@@ -234,6 +245,7 @@ export function SelectContent(_props: SelectContentProps) {
 				</div>
 				<div
 					aria-hidden
+					role="presentation"
 					class={props.classes?.scrollCaret}
 					data-component="select"
 					data-slot="scroll-caret"
@@ -242,6 +254,9 @@ export function SelectContent(_props: SelectContentProps) {
 					data-testid={props.tid("--scroll-caret-down")}
 					onPointerEnter={() => startCaretScroll("down")}
 					onPointerLeave={stopCaretScroll}
+					onMouseEnter={() => startCaretScroll("down")}
+					onMouseLeave={stopCaretScroll}
+					onClick={() => nudgeScroll("down")}
 				>
 					<ChevronDown />
 				</div>

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -1,6 +1,11 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/solid/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
-import { getSelectScrollState, startSelectCaretAutoScroll } from "@temporal-ui/core/select";
+import {
+	getSelectScrollState,
+	resetSelectLinearAlignment,
+	startSelectCaretAutoScroll,
+	type AlignSelectDropdownResult,
+} from "@temporal-ui/core/select";
 import { CheckIcon, ChevronDown, ChevronUp } from "lucide-solid";
 import {
 	createEffect,
@@ -34,58 +39,75 @@ export interface SelectContentProps {
 export function SelectContent(_props: SelectContentProps) {
 	const props = mergeProps({ maxHeight: 500 }, _props);
 	const context = useSelectContext();
+	const [contentEl, setContentEl] = createSignal<HTMLDivElement | null>(null);
 	const [listEl, setListEl] = createSignal<HTMLDivElement | null>(null);
 	const [canScrollUp, setCanScrollUp] = createSignal(false);
 	const [canScrollDown, setCanScrollDown] = createSignal(false);
 	let stopAutoScroll: (() => void) | null = null;
 
+	const applyScrollState = (state: AlignSelectDropdownResult) => {
+		setCanScrollUp(state.canScrollUp);
+		setCanScrollDown(state.canScrollDown);
+	};
+
 	const syncScrollState = () => {
 		const list = listEl();
 		if (!list) return;
-		const state = getSelectScrollState(list);
-		setCanScrollUp(state.canScrollUp);
-		setCanScrollDown(state.canScrollDown);
+		applyScrollState(getSelectScrollState(list));
 	};
 
 	createEffect(() => {
 		const open = context().open;
 		const value = context().value;
+		void value;
 
 		if (!open) {
 			setCanScrollUp(false);
 			setCanScrollDown(false);
 			stopAutoScroll?.();
 			stopAutoScroll = null;
+			resetSelectLinearAlignment(contentEl());
 			return;
 		}
 
-		// Depend on value so re-open with a new selection refreshes caret state.
-		void value;
-
-		const frame = requestAnimationFrame(() => {
-			syncScrollState();
-		});
+		const frame = requestAnimationFrame(syncScrollState);
+		const poll = window.setInterval(syncScrollState, 50);
+		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 400);
 
 		onCleanup(() => {
 			cancelAnimationFrame(frame);
+			window.clearInterval(poll);
+			window.clearTimeout(stopPoll);
 			stopAutoScroll?.();
 			stopAutoScroll = null;
 		});
 	});
 
 	createEffect(() => {
+		const content = contentEl();
 		const list = listEl();
 		const open = context().open;
-		if (!list || !open) return;
+		if (!content || !list || !open) return;
+
+		const onAligned = (event: Event) => {
+			const detail = (event as CustomEvent<AlignSelectDropdownResult>).detail;
+			if (detail) {
+				applyScrollState(detail);
+			} else {
+				syncScrollState();
+			}
+		};
 
 		const observer = new ResizeObserver(() => {
 			syncScrollState();
 		});
 		observer.observe(list);
+		content.addEventListener("temporal-ui:select-aligned", onAligned);
 		list.addEventListener("scroll", syncScrollState, { passive: true });
 
 		onCleanup(() => {
 			observer.disconnect();
+			content.removeEventListener("temporal-ui:select-aligned", onAligned);
 			list.removeEventListener("scroll", syncScrollState);
 		});
 	});
@@ -97,10 +119,7 @@ export function SelectContent(_props: SelectContentProps) {
 		stopAutoScroll = startSelectCaretAutoScroll({
 			scroller: list,
 			direction,
-			onScroll: (state) => {
-				setCanScrollUp(state.canScrollUp);
-				setCanScrollDown(state.canScrollDown);
-			},
+			onScroll: applyScrollState,
 		});
 	};
 
@@ -112,6 +131,7 @@ export function SelectContent(_props: SelectContentProps) {
 	return (
 		<ArkSelect.Positioner class={props.classes?.positioner} data-testid={props.tid("--positioner")}>
 			<ArkSelect.Content
+				ref={setContentEl}
 				class={props.classes?.content}
 				data-testid={props.tid("--content")}
 				style={{ "max-height": `${props.maxHeight}px` }}
@@ -124,8 +144,8 @@ export function SelectContent(_props: SelectContentProps) {
 					data-direction="up"
 					data-visible={canScrollUp() ? "" : undefined}
 					data-testid={props.tid("--scroll-caret-up")}
-					onMouseEnter={() => startCaretScroll("up")}
-					onMouseLeave={stopCaretScroll}
+					onPointerEnter={() => startCaretScroll("up")}
+					onPointerLeave={stopCaretScroll}
 				>
 					<ChevronUp />
 				</div>
@@ -186,8 +206,8 @@ export function SelectContent(_props: SelectContentProps) {
 					data-direction="down"
 					data-visible={canScrollDown() ? "" : undefined}
 					data-testid={props.tid("--scroll-caret-down")}
-					onMouseEnter={() => startCaretScroll("down")}
-					onMouseLeave={stopCaretScroll}
+					onPointerEnter={() => startCaretScroll("down")}
+					onPointerLeave={stopCaretScroll}
 				>
 					<ChevronDown />
 				</div>

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -154,7 +154,6 @@ export function SelectContent(_props: SelectContentProps) {
 					data-component="select"
 					data-slot="list"
 					data-testid={props.tid("--content-list")}
-					style={{ "max-height": "100%", height: "100%" }}
 					onScroll={syncScrollState}
 				>
 					<For each={context().collection.group()}>

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -1,7 +1,10 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/solid/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
 import {
+	alignSelectDropdown,
+	getSelectedSelectItem,
 	getSelectScrollState,
+	getSelectTriggerForContent,
 	resetSelectLinearAlignment,
 	startSelectCaretAutoScroll,
 	type AlignSelectDropdownResult,
@@ -56,6 +59,24 @@ export function SelectContent(_props: SelectContentProps) {
 		applyScrollState(getSelectScrollState(list));
 	};
 
+	const runLinearAlign = () => {
+		const content = contentEl();
+		if (!content || content.hidden) return false;
+		const positioner = content.closest<HTMLElement>('[data-part="positioner"]');
+		const trigger = getSelectTriggerForContent(content);
+		if (!positioner || !trigger) return false;
+
+		const state = alignSelectDropdown({
+			positioner,
+			content,
+			trigger,
+			selectedItem: getSelectedSelectItem(content),
+			maxHeight: props.maxHeight,
+		});
+		applyScrollState(state);
+		return content.dataset.linearAligned === "true";
+	};
+
 	createEffect(() => {
 		const open = context().open;
 		const value = context().value;
@@ -70,14 +91,22 @@ export function SelectContent(_props: SelectContentProps) {
 			return;
 		}
 
-		const frame = requestAnimationFrame(syncScrollState);
-		const poll = window.setInterval(syncScrollState, 50);
-		const stopPoll = window.setTimeout(() => window.clearInterval(poll), 400);
+		// Clear any premature lock from floating-ui's first paint, then align.
+		resetSelectLinearAlignment(contentEl());
+
+		let retries = 0;
+		let frame = 0;
+		const tryAlign = () => {
+			if (runLinearAlign() || retries++ >= 16) {
+				syncScrollState();
+				return;
+			}
+			frame = requestAnimationFrame(tryAlign);
+		};
+		frame = requestAnimationFrame(tryAlign);
 
 		onCleanup(() => {
 			cancelAnimationFrame(frame);
-			window.clearInterval(poll);
-			window.clearTimeout(stopPoll);
 			stopAutoScroll?.();
 			stopAutoScroll = null;
 		});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Select dropdowns now open **Linear-style**: the menu overlays the trigger and aligns to the currently selected item (when set), stays within the viewport, and shows small carets that auto-scroll on hover (and nudge on click) when the list doesn’t fit.

## Changes

- **Core**: `alignSelectDropdown`, `createLinearSelectPositioning`, and scroll-caret helpers (with unit tests)
- **React & Solid Select**: default Linear positioning; scroll carets in `SelectContent`
- **CSS**: scrollable list with absolute carets; native scrollbar hidden
- **Storybook**:
  - `Linear style (aligned selection)`
  - `Linear style (near top edge + carets)`
  - `Linear style (open with carets)` (pre-opened for easy review)

## How to verify

1. `bun run react` → **React/Select**
2. **Linear style (aligned selection)** — selected item sits on the trigger
3. **Linear style (open with carets)** — carets at the edges; hover or click to scroll

## Proof of work

![Mango aligned over trigger](https://cursor.com/artifacts/c/art-e8d7f41b-84f3-44cb-abd3-f931ad6a176a)
![Pre-opened near edge with Passion fruit](https://cursor.com/artifacts/c/art-65ab9d7d-bee1-4ab7-a2a3-36b2bdc734e3)
![Up scroll caret](https://cursor.com/artifacts/c/art-ee746db4-4afd-4159-9930-54c8a25a3c85)
![Down scroll caret](https://cursor.com/artifacts/c/art-b8a8013c-cab6-48f9-90fe-0b04f407b142)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eea561c7-7d43-4a43-b0b1-747d426b4dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eea561c7-7d43-4a43-b0b1-747d426b4dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

