### PR TITLE
feat(select): add alignItemWithTrigger macOS-style alignment (TPX-916)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "temporal-ui",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"private": true,
 	"description": "Monorepo for Temporal UI Design System (React, Solid bindings)",
 	"license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/core",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"description": "Framework-agnostic core definitions, utils and styles for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/core/src/components/select/align-item-with-trigger.test.ts
+++ b/packages/core/src/components/select/align-item-with-trigger.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ALIGN_ITEM_WITH_TRIGGER_EDGE_THRESHOLD,
+	computeAlignItemWithTrigger,
+	querySelectedItemEl,
+} from "./align-item-with-trigger";
+
+function mockRect(top: number, height = 36, left = 0, width = 200): DOMRect {
+	return {
+		top,
+		left,
+		bottom: top + height,
+		right: left + width,
+		width,
+		height,
+		x: left,
+		y: top,
+		toJSON: () => ({}),
+	} as DOMRect;
+}
+
+function mockComputedStyle(
+	element: HTMLElement,
+	styles: Partial<CSSStyleDeclaration> & Record<string, string>,
+) {
+	vi.spyOn(window, "getComputedStyle").mockImplementation((target) => {
+		if (target === element) {
+			return styles as CSSStyleDeclaration;
+		}
+		return {
+			borderBottomWidth: "0",
+			marginTop: "10",
+			marginBottom: "10",
+			minHeight: "100",
+		} as CSSStyleDeclaration;
+	});
+}
+
+function createAlignFixture(opts?: {
+	triggerTop?: number;
+	itemTextTop?: number;
+	valueTextTop?: number;
+	positionerTop?: number;
+	scrollHeight?: number;
+	viewportWidth?: number;
+}) {
+	const triggerTop = opts?.triggerTop ?? 100;
+	const valueTextTop = opts?.valueTextTop ?? triggerTop + 10;
+	const itemTextTop = opts?.itemTextTop ?? valueTextTop + 40;
+	const positionerTop = opts?.positionerTop ?? triggerTop + 8;
+
+	const controlEl = document.createElement("div");
+	const triggerEl = document.createElement("button");
+	const valueTextEl = document.createElement("span");
+	valueTextEl.setAttribute("data-part", "value-text");
+	const contentEl = document.createElement("div");
+	const positionerEl = document.createElement("div");
+	const selectedItemEl = document.createElement("div");
+	const itemTextEl = document.createElement("span");
+	itemTextEl.setAttribute("data-part", "item-text");
+
+	selectedItemEl.appendChild(itemTextEl);
+	contentEl.appendChild(selectedItemEl);
+
+	vi.spyOn(controlEl, "getBoundingClientRect").mockReturnValue(mockRect(triggerTop, 36, 0, 250));
+	vi.spyOn(triggerEl, "getBoundingClientRect").mockReturnValue(mockRect(triggerTop));
+	vi.spyOn(valueTextEl, "getBoundingClientRect").mockReturnValue(mockRect(valueTextTop, 16, 12));
+	vi.spyOn(itemTextEl, "getBoundingClientRect").mockReturnValue(mockRect(itemTextTop, 16, 12));
+	vi.spyOn(positionerEl, "getBoundingClientRect").mockReturnValue(
+		mockRect(positionerTop, 200, 0, 220),
+	);
+	vi.spyOn(contentEl, "getBoundingClientRect").mockReturnValue(mockRect(positionerTop, 200));
+
+	Object.defineProperty(contentEl, "scrollTop", {
+		writable: true,
+		value: 0,
+	});
+	Object.defineProperty(contentEl, "scrollHeight", {
+		configurable: true,
+		value: opts?.scrollHeight ?? 400,
+	});
+	Object.defineProperty(contentEl, "clientHeight", {
+		configurable: true,
+		value: 200,
+	});
+
+	Object.defineProperty(document.documentElement, "clientWidth", {
+		configurable: true,
+		value: opts?.viewportWidth ?? 1024,
+	});
+
+	mockComputedStyle(positionerEl, {
+		marginTop: "10",
+		marginBottom: "10",
+		minHeight: "100",
+	});
+	mockComputedStyle(contentEl, {
+		borderBottomWidth: "1",
+	});
+
+	return {
+		controlEl,
+		triggerEl,
+		valueTextEl,
+		contentEl,
+		positionerEl,
+		selectedItemEl,
+	};
+}
+
+describe("computeAlignItemWithTrigger", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns fallback when there is no selected item", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture();
+		const result = computeAlignItemWithTrigger({
+			...fixture,
+			selectedItemEl: null,
+		});
+
+		expect(result.status).toBe("fallback");
+	});
+
+	it("returns fallback when trigger is too close to the viewport edge", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture({
+			triggerTop: ALIGN_ITEM_WITH_TRIGGER_EDGE_THRESHOLD - 1,
+		});
+
+		const result = computeAlignItemWithTrigger(fixture);
+
+		expect(result.status).toBe("fallback");
+	});
+
+	it("returns fixed positioner styles that override ark transform positioning", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture();
+		const result = computeAlignItemWithTrigger(fixture);
+
+		expect(result.status).toBe("aligned");
+		if (result.status !== "aligned") {
+			return;
+		}
+
+		expect(result.styles.popup.position).toBe("fixed");
+		expect(result.styles.popup.transform).toBe("none");
+		expect(result.styles.popup.width).toBe("250px");
+		expect(result.styles.positioner.position).toBe("static");
+		expect(result.styles.content.maxHeight).toBe("100%");
+		expect(result.styles.scrollTop).toBeGreaterThanOrEqual(0);
+	});
+
+	it("offsets the popup from the viewport by the margin alone", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture();
+		const result = computeAlignItemWithTrigger(fixture);
+
+		expect(result.status).toBe("aligned");
+		if (result.status !== "aligned") {
+			return;
+		}
+
+		// idealHeight = 722 -> topOffset = 780 - 722 = 58; the 10px gap to the
+		// viewport must come from the margin, not be baked into `top` as well.
+		expect(result.styles.popup.top).toBe("58px");
+		expect(result.styles.popup.marginTop).toBe("10px");
+	});
+
+	it("widens the popup to fit the widest item and cover the control", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture();
+		Object.defineProperty(fixture.contentEl, "scrollWidth", {
+			configurable: true,
+			value: 320,
+		});
+
+		const result = computeAlignItemWithTrigger(fixture);
+
+		expect(result.status).toBe("aligned");
+		if (result.status !== "aligned") {
+			return;
+		}
+
+		// 320px of natural item width wins over the 250px control width.
+		expect(result.styles.popup.width).toBe("320px");
+	});
+
+	it("extends the popup to fully cover the control when shifted left", () => {
+		Object.defineProperty(document.documentElement, "clientHeight", {
+			configurable: true,
+			value: 800,
+		});
+
+		const fixture = createAlignFixture();
+		// Item text sits 40px to the right of the value text (indicator gutter),
+		// so the popup shifts 40px left of the control.
+		vi.spyOn(
+			fixture.selectedItemEl.querySelector("[data-part='item-text']")!,
+			"getBoundingClientRect",
+		).mockReturnValue(mockRect(150, 16, 52));
+
+		const result = computeAlignItemWithTrigger(fixture);
+
+		expect(result.status).toBe("aligned");
+		if (result.status !== "aligned") {
+			return;
+		}
+
+		// Control spans 0..250, popup left is clamped to 5 -> width must still
+		// reach the control's right edge when possible (250 - (-40) = 290).
+		expect(result.styles.popup.width).toBe("290px");
+	});
+
+	it("queries the checked item element", () => {
+		const contentEl = document.createElement("div");
+		const unchecked = document.createElement("div");
+		unchecked.setAttribute("data-part", "item");
+		unchecked.setAttribute("data-state", "unchecked");
+		const checked = document.createElement("div");
+		checked.setAttribute("data-part", "item");
+		checked.setAttribute("data-state", "checked");
+		const highlighted = document.createElement("div");
+		highlighted.setAttribute("data-part", "item");
+		highlighted.setAttribute("data-highlighted", "");
+		contentEl.append(unchecked, highlighted, checked);
+
+		expect(querySelectedItemEl(contentEl)).toBe(checked);
+	});
+});

--- a/packages/core/src/components/select/align-item-with-trigger.ts
+++ b/packages/core/src/components/select/align-item-with-trigger.ts
@@ -1,0 +1,224 @@
+export const ALIGN_ITEM_WITH_TRIGGER_EDGE_THRESHOLD = 20;
+export const ALIGN_ITEM_WITH_TRIGGER_DEFAULT_MIN_HEIGHT = 100;
+export const ALIGN_ITEM_WITH_TRIGGER_MARGIN = 10;
+export const ALIGN_ITEM_WITH_TRIGGER_VIEWPORT_PADDING = 5;
+export const ALIGN_ITEM_WITH_TRIGGER_SCROLL_EDGE_TOLERANCE = 1;
+/** Max layout passes to wait for portaled DOM nodes before falling back to standard placement. */
+export const ALIGN_ITEM_WITH_TRIGGER_MAX_RETRIES = 10;
+
+export const alignItemWithTriggerPositioning = {
+	strategy: "fixed" as const,
+	overlap: false,
+	gutter: 0,
+	sameWidth: true,
+	fitViewport: false,
+	placement: "bottom-start" as const,
+	listeners: false,
+};
+
+export const alignItemWithTriggerFallbackPositioning = {
+	placement: "bottom-start" as const,
+	overlap: false,
+	gutter: 8,
+	listeners: true,
+};
+
+/** Neutralizes Ark popper transforms on the positioner while aligned. */
+export const alignItemWithTriggerPositionerReset: Record<string, string> = {
+	position: "static",
+	transform: "none",
+	top: "auto",
+	left: "auto",
+	right: "auto",
+	bottom: "auto",
+	width: "auto",
+	height: "auto",
+	margin: "0",
+	overflow: "visible",
+};
+
+export interface AlignItemWithTriggerOptions {
+	controlEl: HTMLElement;
+	triggerEl: HTMLElement;
+	valueTextEl: HTMLElement;
+	contentEl: HTMLElement;
+	positionerEl: HTMLElement;
+	selectedItemEl: HTMLElement | null;
+	minHeight?: number;
+}
+
+export interface AlignItemWithTriggerStyles {
+	positioner: Record<string, string>;
+	popup: Record<string, string>;
+	content: Record<string, string>;
+	scrollTop: number;
+}
+
+export type AlignItemWithTriggerResult =
+	| { status: "aligned"; styles: AlignItemWithTriggerStyles }
+	| { status: "fallback" };
+
+function getItemTextEl(itemEl: HTMLElement): HTMLElement | null {
+	return itemEl.querySelector('[data-part="item-text"]');
+}
+
+function isPinchZoomed(): boolean {
+	return (window.visualViewport?.scale ?? 1) !== 1;
+}
+
+/**
+ * Computes fixed popup styles so the selected item text aligns with the trigger
+ * value text. Adapted from Base UI's alignItemWithTrigger logic.
+ *
+ * Note on measurement: zag scrolls the selected item into view on open, so the
+ * content may already be scrolled when this runs. `contentEl.scrollTop` is added
+ * back to derive the unscrolled item geometry, and the popup width is derived
+ * from the natural (unwrapped, `white-space: nowrap` in this mode) item widths
+ * via `scrollWidth`, both of which are independent of the scroll/pending state.
+ */
+export function computeAlignItemWithTrigger(
+	options: AlignItemWithTriggerOptions,
+): AlignItemWithTriggerResult {
+	const { controlEl, triggerEl, valueTextEl, contentEl, positionerEl, selectedItemEl } = options;
+
+	if (!selectedItemEl) {
+		return { status: "fallback" };
+	}
+
+	const itemTextEl = getItemTextEl(selectedItemEl);
+	if (!itemTextEl) {
+		return { status: "fallback" };
+	}
+
+	const positionerStyles = getComputedStyle(positionerEl);
+	const contentStyles = getComputedStyle(contentEl);
+	const triggerRect = triggerEl.getBoundingClientRect();
+	const controlRect = controlEl.getBoundingClientRect();
+	const positionerRect = positionerEl.getBoundingClientRect();
+
+	const contentBordersX =
+		(Number.parseFloat(contentStyles.borderLeftWidth) || 0) +
+		(Number.parseFloat(contentStyles.borderRightWidth) || 0);
+	const contentBordersY =
+		(Number.parseFloat(contentStyles.borderTopWidth) || 0) +
+		(Number.parseFloat(contentStyles.borderBottomWidth) || 0);
+	const marginTop = Number.parseFloat(positionerStyles.marginTop) || ALIGN_ITEM_WITH_TRIGGER_MARGIN;
+	const marginBottom =
+		Number.parseFloat(positionerStyles.marginBottom) || ALIGN_ITEM_WITH_TRIGGER_MARGIN;
+	const minHeight =
+		options.minHeight ??
+		(Number.parseFloat(positionerStyles.minHeight) || ALIGN_ITEM_WITH_TRIGGER_DEFAULT_MIN_HEIGHT);
+
+	const viewportHeight = document.documentElement.clientHeight - marginTop - marginBottom;
+	const viewportWidth = document.documentElement.clientWidth;
+	const availableSpaceBeneathTrigger = viewportHeight - triggerRect.bottom + triggerRect.height;
+	// Natural height of the list (unaffected by the pending max-height clamp).
+	const scrollHeight = contentEl.scrollHeight;
+
+	const valueRect = valueTextEl.getBoundingClientRect();
+	const textRect = itemTextEl.getBoundingClientRect();
+
+	const alignedLeft = positionerRect.left + (valueRect.left - textRect.left);
+	const valueCenterFromTriggerTop = valueRect.top - triggerRect.top + valueRect.height / 2;
+	const textCenterFromPositionerTop =
+		textRect.top - positionerRect.top + textRect.height / 2 + contentEl.scrollTop;
+	const offsetY = textCenterFromPositionerTop - valueCenterFromTriggerTop;
+
+	const idealHeight = availableSpaceBeneathTrigger + offsetY + marginBottom;
+	let height = Math.min(viewportHeight, idealHeight);
+	const maxHeight = viewportHeight - marginTop - marginBottom;
+	const scrollTop = idealHeight - height;
+
+	// The popup is at least as wide as needed to fully cover the control, even
+	// when shifted left by the item indicator gutter.
+	const naturalWidth = contentEl.scrollWidth + contentBordersX;
+	const minWidth = Math.max(
+		controlRect.width,
+		controlRect.right - Math.min(alignedLeft, controlRect.left),
+	);
+	const width = Math.min(
+		Math.max(naturalWidth, minWidth),
+		viewportWidth - ALIGN_ITEM_WITH_TRIGGER_VIEWPORT_PADDING * 2,
+	);
+
+	const maxRight = viewportWidth - ALIGN_ITEM_WITH_TRIGGER_VIEWPORT_PADDING;
+	const left = Math.min(
+		Math.max(alignedLeft, ALIGN_ITEM_WITH_TRIGGER_VIEWPORT_PADDING),
+		Math.max(ALIGN_ITEM_WITH_TRIGGER_VIEWPORT_PADDING, maxRight - width),
+	);
+
+	// Scroll bounds as they will be once `height` is applied (content max-height: 100%).
+	const maxScrollTop = Math.max(0, scrollHeight - height + contentBordersY);
+	const isTopPositioned = scrollTop >= maxScrollTop - ALIGN_ITEM_WITH_TRIGGER_SCROLL_EDGE_TOLERANCE;
+
+	if (isTopPositioned) {
+		height = Math.min(viewportHeight, scrollHeight + contentBordersY) - (scrollTop - maxScrollTop);
+	}
+
+	const fallbackToAlignPopupToTrigger =
+		triggerRect.top < ALIGN_ITEM_WITH_TRIGGER_EDGE_THRESHOLD ||
+		triggerRect.bottom >
+			document.documentElement.clientHeight - ALIGN_ITEM_WITH_TRIGGER_EDGE_THRESHOLD ||
+		Math.ceil(height) + ALIGN_ITEM_WITH_TRIGGER_SCROLL_EDGE_TOLERANCE <
+			Math.min(scrollHeight, minHeight) ||
+		isPinchZoomed();
+
+	if (fallbackToAlignPopupToTrigger) {
+		return { status: "fallback" };
+	}
+
+	const popup: Record<string, string> = {
+		position: "fixed",
+		left: `${left}px`,
+		width: `${width}px`,
+		height: `${height}px`,
+		maxHeight: "none",
+		marginTop: `${marginTop}px`,
+		marginBottom: `${marginBottom}px`,
+		right: "auto",
+		transform: "none",
+		top: "auto",
+		bottom: "auto",
+		zIndex: positionerStyles.zIndex === "auto" ? "50" : positionerStyles.zIndex,
+	};
+
+	let contentScrollTop = scrollTop;
+
+	if (isTopPositioned) {
+		const topOffset = Math.max(0, viewportHeight - idealHeight);
+		popup.top = scrollHeight + contentBordersY >= maxHeight ? "0px" : `${topOffset}px`;
+		contentScrollTop = Math.max(0, scrollHeight - Math.min(scrollHeight, height - contentBordersY));
+	} else {
+		popup.bottom = "0px";
+	}
+
+	return {
+		status: "aligned",
+		styles: {
+			positioner: { ...alignItemWithTriggerPositionerReset },
+			popup,
+			content: { maxHeight: "100%" },
+			scrollTop: contentScrollTop,
+		},
+	};
+}
+
+export function querySelectedItemEl(contentEl: HTMLElement): HTMLElement | null {
+	return contentEl.querySelector('[data-part="item"][data-state="checked"]');
+}
+
+export function areAlignItemWithTriggerStylesEqual(
+	current: AlignItemWithTriggerStyles | undefined,
+	next: AlignItemWithTriggerStyles,
+): boolean {
+	if (!current) {
+		return false;
+	}
+
+	return (
+		current.scrollTop === next.scrollTop &&
+		JSON.stringify(current.positioner) === JSON.stringify(next.positioner) &&
+		JSON.stringify(current.popup) === JSON.stringify(next.popup) &&
+		JSON.stringify(current.content) === JSON.stringify(next.content)
+	);
+}

--- a/packages/core/src/components/select/index.ts
+++ b/packages/core/src/components/select/index.ts
@@ -1,1 +1,2 @@
+export * from "./align-item-with-trigger";
 export * from "./select";

--- a/packages/core/src/components/select/select.css
+++ b/packages/core/src/components/select/select.css
@@ -48,6 +48,85 @@
 		}
 	}
 
+	[data-align-item-with-trigger] {
+		[data-scope="select"][data-part="trigger"] {
+			@apply pl-3;
+		}
+	}
+
+	/* Gated on the positioner itself rather than the root so these rules still
+	   apply when the dropdown is portaled out of the root element. */
+	[data-scope="select"][data-part="positioner"][data-align-item-with-trigger] {
+		&[data-align-item-with-trigger-pending] {
+			opacity: 0;
+			pointer-events: none;
+		}
+
+		&:has([data-align-item-with-trigger-active]) {
+			position: static !important;
+			transform: none !important;
+			top: auto !important;
+			left: auto !important;
+			right: auto !important;
+			bottom: auto !important;
+			width: auto !important;
+			height: auto !important;
+			margin: 0 !important;
+			overflow: visible !important;
+		}
+
+		[data-scope="select"][data-part="content"] {
+			@apply scroll-py-0;
+			animation: none !important;
+			transition: none !important;
+
+			&[data-state="open"],
+			&[data-state="closed"] {
+				animation: none !important;
+			}
+
+			&[data-placement*="bottom"],
+			&[data-placement*="top"],
+			&[data-placement*="left"],
+			&[data-placement*="right"] {
+				@apply translate-x-0 translate-y-0;
+			}
+		}
+
+		[data-align-item-with-trigger-active] {
+			@apply overflow-y-auto overflow-x-hidden;
+			max-height: 100%;
+			overflow-anchor: none;
+			transition: none !important;
+
+			[data-scope="select"][data-part="content"] {
+				max-height: 100%;
+			}
+
+			[data-part="item"] {
+				scroll-margin-block: 0;
+			}
+		}
+
+		[data-scope="select"][data-part="item-group"],
+		[data-component="select"][data-slot="list"] {
+			[data-part="item"] {
+				/* Reserve a left gutter for the check indicator (macOS-style). */
+				@apply pl-8 pr-3;
+			}
+
+			/* Items must not wrap: the popup width derives from the widest item. */
+			[data-part="item-text"],
+			[data-part="item-group-label"] {
+				@apply whitespace-nowrap;
+			}
+
+			[data-part="item-indicator"] {
+				@apply left-2.5 right-auto;
+			}
+		}
+	}
+
 	[data-scope="combobox"][data-part="input"] {
 		@apply w-full outline-none text-sm;
 	}

--- a/packages/core/src/components/select/select.ts
+++ b/packages/core/src/components/select/select.ts
@@ -15,6 +15,10 @@ export interface SelectProps<T = unknown> extends FieldProps<T> {
 	maxDropdownHeight?: number;
 	deselectable?: boolean;
 	placeholder?: string;
+	/** Overlap the dropdown on the trigger so selected item text aligns with the value text. */
+	alignItemWithTrigger?: boolean;
+	/** Minimum dropdown height required before falling back to standard placement. */
+	alignItemWithTriggerMinHeight?: number;
 	classes?: {
 		root?: string;
 		label?: string;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/react",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"description": "React bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -1,9 +1,9 @@
 // noinspection JSUnusedGlobalSymbols
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Select } from "./Select";
-import { createListCollection, type SelectItem } from ".";
 import { Banana } from "lucide-react";
+import { createListCollection, type SelectItem } from ".";
+import { Select } from "./Select";
 
 const meta = {
 	title: "React/Select",
@@ -72,6 +72,48 @@ export const Deselectable: Story = {
 		...Default.args,
 		deselectable: true,
 	},
+};
+
+export const AlignItemWithTrigger: Story = {
+	args: {
+		className: "min-w-[250px]",
+		collection: createListCollection({
+			items: [
+				{ value: "small", label: "Small" },
+				{ value: "medium", label: "Medium" },
+				{ value: "large", label: "Large" },
+				{ value: "xlarge", label: "Extra large" },
+				{ value: "huge", label: "Unbelievably, comically, ridiculously large" },
+			],
+		}),
+		placeholder: "Select a size",
+		label: "Size",
+		portal: true,
+		alignItemWithTrigger: true,
+		defaultValue: ["medium"],
+	},
+	render: (args) => (
+		<div className="flex min-h-screen items-center justify-center p-8">
+			<Select {...args} />
+		</div>
+	),
+};
+
+export const AlignItemWithTriggerLongList: Story = {
+	args: {
+		className: "min-w-[250px]",
+		collection,
+		placeholder: "Select a fruit",
+		label: "Fruits",
+		portal: true,
+		alignItemWithTrigger: true,
+		defaultValue: ["raspberry"],
+	},
+	render: (args) => (
+		<div className="flex min-h-screen items-center justify-center p-8">
+			<Select {...args} />
+		</div>
+	),
 };
 
 export const LargeDataset: Story = {

--- a/packages/react/src/components/select/Select.test.tsx
+++ b/packages/react/src/components/select/Select.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { createListCollection, Select, type SelectItem } from ".";
 
@@ -40,5 +41,111 @@ describe("Select", () => {
 		);
 		expect(screen.getByTestId("sel2--trigger")).toHaveClass("slot-trigger");
 		expect(screen.getByTestId("sel2--value-text")).toHaveClass("slot-value");
+	});
+
+	it("sets data-align-item-with-trigger when alignItemWithTrigger is enabled", () => {
+		render(
+			<Select
+				testId="sel3"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+			/>,
+		);
+		expect(screen.getByTestId("sel3--root")).toHaveAttribute("data-align-item-with-trigger");
+	});
+
+	it("reopens after closing when alignItemWithTrigger is enabled", async () => {
+		const user = userEvent.setup();
+		render(
+			<Select
+				testId="sel4"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+				defaultValue={["a"]}
+			/>,
+		);
+
+		await user.click(screen.getByTestId("sel4--trigger"));
+		expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "true");
+		expect(await screen.findByTestId("sel4--content")).toBeVisible();
+
+		await user.keyboard("{Escape}");
+		await waitFor(() => {
+			expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "false");
+		});
+
+		await user.click(screen.getByTestId("sel4--trigger"));
+		await waitFor(() => {
+			expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "true");
+		});
+		expect(await screen.findByTestId("sel4--content")).toBeVisible();
+	});
+
+	it("shows dropdown when alignItemWithTrigger is enabled with no selection", async () => {
+		const user = userEvent.setup();
+		render(
+			<Select
+				testId="sel5"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+			/>,
+		);
+
+		await user.click(screen.getByTestId("sel5--trigger"));
+
+		expect(await screen.findByTestId("sel5--content")).toBeVisible();
+		await waitFor(() => {
+			expect(screen.getByTestId("sel5--positioner")).not.toHaveAttribute(
+				"data-align-item-with-trigger-pending",
+			);
+		});
+	});
+
+	it("skips alignment when opened via touch", async () => {
+		render(
+			<Select
+				testId="sel6"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+				defaultValue={["a"]}
+			/>,
+		);
+
+		const trigger = screen.getByTestId("sel6--trigger");
+		fireEvent.pointerDown(trigger, { pointerType: "touch" });
+		fireEvent.click(trigger);
+
+		expect(await screen.findByTestId("sel6--content")).toBeVisible();
+		expect(screen.getByTestId("sel6--positioner")).not.toHaveAttribute(
+			"data-align-item-with-trigger",
+		);
+	});
+
+	it("preserves custom ids when alignItemWithTrigger is disabled", () => {
+		render(
+			<Select
+				testId="sel7"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				ids={{ trigger: "custom-trigger", content: "custom-content" }}
+			/>,
+		);
+
+		expect(screen.getByTestId("sel7--trigger")).toHaveAttribute("id", "custom-trigger");
+		expect(screen.getByTestId("sel7--content")).toHaveAttribute("id", "custom-content");
 	});
 });

--- a/packages/react/src/components/select/Select.tsx
+++ b/packages/react/src/components/select/Select.tsx
@@ -1,11 +1,13 @@
-import { Select as ArkSelect, useSelect, type CollectionItem } from "@ark-ui/react/select";
 import { Portal } from "@ark-ui/react/portal";
+import { Select as ArkSelect, useSelect, type CollectionItem } from "@ark-ui/react/select";
 import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import { alignItemWithTriggerPositioning } from "@temporal-ui/core/select";
 import { cx } from "@temporal-ui/core/utils/cx";
-import { Field } from "../field";
-import { SelectContent, type SelectItem } from "./SelectContent";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-react";
+import { useEffect, useId, useMemo, useState } from "react";
+import { Field } from "../field";
+import { SelectContent, type SelectItem } from "./SelectContent";
 
 export interface SelectProps<D extends CollectionItem = never>
 	extends CoreSelectProps<React.ReactNode>, ArkSelect.RootProps<SelectItem<D>> {}
@@ -26,8 +28,28 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		className,
 		maxDropdownHeight,
 		deselectable,
+		alignItemWithTrigger,
+		alignItemWithTriggerMinHeight,
+		positioning,
+		ids,
 		...rootProps
 	} = props;
+
+	const [openedWithTouch, setOpenedWithTouch] = useState(false);
+	const instanceId = useId().replace(/:/g, "");
+	const selectIds = useMemo(
+		() =>
+			alignItemWithTrigger
+				? {
+						control: `${instanceId}-control`,
+						trigger: `${instanceId}-trigger`,
+						valueText: `${instanceId}-value-text`,
+						positioner: `${instanceId}-positioner`,
+						content: `${instanceId}-content`,
+					}
+				: undefined,
+		[instanceId, alignItemWithTrigger],
+	);
 
 	const select = useSelect({
 		...rootProps,
@@ -35,9 +57,32 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 		invalid: !!error,
 		required,
 		readOnly,
+		ids:
+			alignItemWithTrigger && selectIds
+				? {
+						...ids,
+						control: selectIds.control,
+						trigger: selectIds.trigger,
+						positioner: selectIds.positioner,
+						content: selectIds.content,
+					}
+				: ids,
+		positioning: alignItemWithTrigger
+			? {
+					...alignItemWithTriggerPositioning,
+					...positioning,
+					getAnchorElement: () => document.getElementById(selectIds!.control),
+				}
+			: positioning,
 	});
 
 	const tid = testId(testIdProp);
+
+	useEffect(() => {
+		if (!select.open) {
+			setOpenedWithTouch(false);
+		}
+	}, [select.open]);
 
 	return (
 		<Field
@@ -54,15 +99,29 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 				value={select}
 				className={classes?.selectRoot}
 				data-testid={tid("--root")}
+				data-align-item-with-trigger={alignItemWithTrigger ? "" : undefined}
 			>
 				<ArkSelect.Control
+					id={selectIds?.control}
 					aria-invalid={!!error}
 					className={cx(classes?.control, className)}
 					data-testid={tid("--control")}
 				>
-					<ArkSelect.Trigger className={classes?.trigger} data-testid={tid("--trigger")}>
+					<ArkSelect.Trigger
+						id={selectIds?.trigger}
+						className={classes?.trigger}
+						data-testid={tid("--trigger")}
+						onPointerDown={
+							alignItemWithTrigger
+								? (event) => {
+										setOpenedWithTouch(event.pointerType === "touch");
+									}
+								: undefined
+						}
+					>
 						{select.selectedItems[0]?.icon || icon}
 						<ArkSelect.ValueText
+							id={selectIds?.valueText}
 							className={classes?.valueText}
 							placeholder={placeholder}
 							data-testid={tid("--value-text")}
@@ -77,10 +136,28 @@ export function Select<D extends CollectionItem>(props: SelectProps<D>) {
 				</ArkSelect.Control>
 				{portal && (
 					<Portal>
-						<SelectContent tid={tid} maxHeight={maxDropdownHeight} classes={classes} />
+						<SelectContent
+							tid={tid}
+							maxHeight={maxDropdownHeight}
+							classes={classes}
+							alignItemWithTrigger={alignItemWithTrigger}
+							alignItemWithTriggerMinHeight={alignItemWithTriggerMinHeight}
+							openedWithTouch={openedWithTouch}
+							selectIds={selectIds}
+						/>
 					</Portal>
 				)}
-				{!portal && <SelectContent tid={tid} maxHeight={maxDropdownHeight} classes={classes} />}
+				{!portal && (
+					<SelectContent
+						tid={tid}
+						maxHeight={maxDropdownHeight}
+						classes={classes}
+						alignItemWithTrigger={alignItemWithTrigger}
+						alignItemWithTriggerMinHeight={alignItemWithTriggerMinHeight}
+						openedWithTouch={openedWithTouch}
+						selectIds={selectIds}
+					/>
+				)}
 				<ArkSelect.HiddenSelect data-testid={tid("--input")} />
 			</ArkSelect.RootProvider>
 		</Field>

--- a/packages/react/src/components/select/SelectContent.tsx
+++ b/packages/react/src/components/select/SelectContent.tsx
@@ -1,12 +1,23 @@
 import { Select as ArkSelect, useSelectContext } from "@ark-ui/react/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
 import { CheckIcon } from "lucide-react";
+import { useAlignItemWithTrigger } from "./use-align-item-with-trigger";
 
 export type SelectItem<D = unknown> = CoreSelectItem<D, React.ReactNode>;
 
 export interface SelectContentProps {
 	tid: (str: string) => string | undefined;
 	maxHeight?: number;
+	alignItemWithTrigger?: boolean;
+	alignItemWithTriggerMinHeight?: number;
+	openedWithTouch?: boolean;
+	selectIds?: {
+		control: string;
+		trigger: string;
+		valueText: string;
+		positioner: string;
+		content: string;
+	};
 	classes?: {
 		content?: string;
 		itemGroup?: string;
@@ -21,56 +32,87 @@ export interface SelectContentProps {
 }
 
 export function SelectContent(props: SelectContentProps) {
-	const { tid, maxHeight = 500, classes } = props;
+	const {
+		tid,
+		maxHeight = 500,
+		classes,
+		alignItemWithTrigger,
+		alignItemWithTriggerMinHeight,
+		openedWithTouch,
+		selectIds,
+	} = props;
 	const context = useSelectContext();
+	const { alignedStyles, isAlignPending, showAligned, shouldAlign } = useAlignItemWithTrigger(
+		context,
+		{
+			alignItemWithTrigger,
+			alignItemWithTriggerMinHeight,
+			openedWithTouch,
+			selectIds,
+		},
+	);
+
 	return (
-		<ArkSelect.Positioner className={classes?.positioner} data-testid={tid("--positioner")}>
-			<ArkSelect.Content
-				className={classes?.content}
-				data-testid={tid("--content")}
-				style={{ maxHeight: `${maxHeight}px` }}
+		<ArkSelect.Positioner
+			id={selectIds?.positioner}
+			className={classes?.positioner}
+			data-testid={tid("--positioner")}
+			data-align-item-with-trigger={shouldAlign ? "" : undefined}
+			data-align-item-with-trigger-pending={isAlignPending ? "" : undefined}
+			style={showAligned ? alignedStyles?.positioner : undefined}
+		>
+			<div
+				data-align-item-with-trigger-active={showAligned ? "" : undefined}
+				style={showAligned ? alignedStyles?.popup : { display: "contents" }}
 			>
-				<div data-component="select" data-slot="list" data-testid={tid("--content-list")}>
-					{context.collection.group().map(([type, group]) => (
-						<ArkSelect.ItemGroup
-							key={type}
-							className={classes?.itemGroup}
-							data-testid={tid("--item-group")}
-						>
-							{type && (
-								<ArkSelect.ItemGroupLabel
-									className={classes?.itemGroupLabel}
-									data-testid={tid("--item-group-label")}
-								>
-									{type}
-								</ArkSelect.ItemGroupLabel>
-							)}
-							{group.map((item) => (
-								<ArkSelect.Item
-									key={item.value}
-									className={classes?.item}
-									data-testid={tid("--item")}
-									item={item}
-								>
-									{item.icon}
-									<ArkSelect.ItemText
-										className={classes?.itemText}
-										data-testid={tid("--item-text")}
+				<ArkSelect.Content
+					id={selectIds?.content}
+					className={classes?.content}
+					data-testid={tid("--content")}
+					style={showAligned ? alignedStyles?.content : { maxHeight: `${maxHeight}px` }}
+				>
+					<div data-component="select" data-slot="list" data-testid={tid("--content-list")}>
+						{context.collection.group().map(([type, group]) => (
+							<ArkSelect.ItemGroup
+								key={type}
+								className={classes?.itemGroup}
+								data-testid={tid("--item-group")}
+							>
+								{type && (
+									<ArkSelect.ItemGroupLabel
+										className={classes?.itemGroupLabel}
+										data-testid={tid("--item-group-label")}
 									>
-										{item.label}
-									</ArkSelect.ItemText>
-									<ArkSelect.ItemIndicator
-										className={classes?.itemIndicator}
-										data-testid={tid("--item-indicator")}
+										{type}
+									</ArkSelect.ItemGroupLabel>
+								)}
+								{group.map((item) => (
+									<ArkSelect.Item
+										key={item.value}
+										className={classes?.item}
+										data-testid={tid("--item")}
+										item={item}
 									>
-										<CheckIcon />
-									</ArkSelect.ItemIndicator>
-								</ArkSelect.Item>
-							))}
-						</ArkSelect.ItemGroup>
-					))}
-				</div>
-			</ArkSelect.Content>
+										<ArkSelect.ItemIndicator
+											className={classes?.itemIndicator}
+											data-testid={tid("--item-indicator")}
+										>
+											<CheckIcon />
+										</ArkSelect.ItemIndicator>
+										{item.icon}
+										<ArkSelect.ItemText
+											className={classes?.itemText}
+											data-testid={tid("--item-text")}
+										>
+											{item.label}
+										</ArkSelect.ItemText>
+									</ArkSelect.Item>
+								))}
+							</ArkSelect.ItemGroup>
+						))}
+					</div>
+				</ArkSelect.Content>
+			</div>
 		</ArkSelect.Positioner>
 	);
 }

--- a/packages/react/src/components/select/use-align-item-with-trigger.ts
+++ b/packages/react/src/components/select/use-align-item-with-trigger.ts
@@ -1,0 +1,145 @@
+import type { useSelectContext } from "@ark-ui/react/select";
+import {
+	ALIGN_ITEM_WITH_TRIGGER_MAX_RETRIES,
+	alignItemWithTriggerFallbackPositioning,
+	areAlignItemWithTriggerStylesEqual,
+	computeAlignItemWithTrigger,
+	querySelectedItemEl,
+	type AlignItemWithTriggerStyles,
+} from "@temporal-ui/core/select";
+import { useLayoutEffect, useRef, useState } from "react";
+import type { SelectContentProps } from "./SelectContent";
+
+function runAfterLayout(callback: () => void) {
+	requestAnimationFrame(() => {
+		requestAnimationFrame(callback);
+	});
+}
+
+export function useAlignItemWithTrigger(
+	context: ReturnType<typeof useSelectContext>,
+	props: Pick<
+		SelectContentProps,
+		"alignItemWithTrigger" | "alignItemWithTriggerMinHeight" | "openedWithTouch" | "selectIds"
+	>,
+) {
+	const [alignedStyles, setAlignedStyles] = useState<AlignItemWithTriggerStyles | undefined>();
+	const [alignEpoch, setAlignEpoch] = useState(0);
+	const [readyEpoch, setReadyEpoch] = useState(0);
+	const sessionRef = useRef(0);
+	const propsRef = useRef(props);
+	propsRef.current = props;
+
+	const repositionRef = useRef(context.reposition);
+	repositionRef.current = context.reposition;
+
+	useLayoutEffect(() => {
+		if (!context.open) {
+			return;
+		}
+
+		const { alignItemWithTrigger, alignItemWithTriggerMinHeight, openedWithTouch, selectIds } =
+			propsRef.current;
+
+		if (!alignItemWithTrigger || openedWithTouch || context.multiple || !selectIds) {
+			return;
+		}
+
+		sessionRef.current += 1;
+		const session = sessionRef.current;
+		setAlignEpoch(session);
+		setAlignedStyles(undefined);
+
+		let cancelled = false;
+		let retries = 0;
+
+		const fallbackToStandardPlacement = () => {
+			setAlignedStyles(undefined);
+			setReadyEpoch(session);
+			repositionRef.current(alignItemWithTriggerFallbackPositioning);
+		};
+
+		const alignOnce = () => {
+			if (cancelled || sessionRef.current !== session) {
+				return;
+			}
+
+			const controlEl = document.getElementById(selectIds.control);
+			const triggerEl = document.getElementById(selectIds.trigger);
+			const valueTextEl = document.getElementById(selectIds.valueText);
+			const positionerEl = document.getElementById(selectIds.positioner);
+			const contentEl = document.getElementById(selectIds.content);
+
+			if (!controlEl || !triggerEl || !valueTextEl || !positionerEl || !contentEl) {
+				if (++retries >= ALIGN_ITEM_WITH_TRIGGER_MAX_RETRIES) {
+					fallbackToStandardPlacement();
+					return;
+				}
+				runAfterLayout(alignOnce);
+				return;
+			}
+
+			const selectedItemEl = querySelectedItemEl(contentEl);
+			if (!selectedItemEl) {
+				fallbackToStandardPlacement();
+				return;
+			}
+
+			const result = computeAlignItemWithTrigger({
+				controlEl,
+				triggerEl,
+				valueTextEl,
+				contentEl,
+				positionerEl,
+				selectedItemEl,
+				minHeight: alignItemWithTriggerMinHeight,
+			});
+
+			if (cancelled || sessionRef.current !== session) {
+				return;
+			}
+
+			if (result.status === "fallback") {
+				fallbackToStandardPlacement();
+				return;
+			}
+
+			setAlignedStyles((current) =>
+				areAlignItemWithTriggerStylesEqual(current, result.styles) ? current : result.styles,
+			);
+			setReadyEpoch(session);
+		};
+
+		queueMicrotask(() => {
+			runAfterLayout(alignOnce);
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [context.open]);
+
+	// Scroll after the aligned styles are committed: the target offset is computed
+	// for the final popup height and would be clamped by the pending max-height.
+	useLayoutEffect(() => {
+		if (!alignedStyles || !context.open || !props.selectIds) {
+			return;
+		}
+		const contentEl = document.getElementById(props.selectIds.content);
+		if (contentEl) {
+			contentEl.scrollTop = alignedStyles.scrollTop;
+		}
+	}, [alignedStyles, context.open, props.selectIds]);
+
+	const shouldAlign = !!(
+		props.alignItemWithTrigger &&
+		!props.openedWithTouch &&
+		!context.multiple &&
+		props.selectIds
+	);
+
+	const isAlignPending = shouldAlign && context.open && readyEpoch !== alignEpoch;
+	const showAligned = !!alignedStyles && context.open && !isAlignPending;
+
+	return { alignedStyles, isAlignPending, showAligned, shouldAlign };
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@temporal-ui/solid",
-	"version": "0.10.1",
+	"version": "0.10.2",
 	"description": "Solid.JS bindings for Temporal UI components",
 	"bugs": {
 		"url": "https://github.com/temporal-app/temporal-ui/issues"

--- a/packages/solid/src/components/select/Select.stories.tsx
+++ b/packages/solid/src/components/select/Select.stories.tsx
@@ -71,6 +71,48 @@ export const Deselectable: Story = {
 	},
 };
 
+export const AlignItemWithTrigger: Story = {
+	args: {
+		className: "min-w-[250px]",
+		collection: createListCollection({
+			items: [
+				{ value: "small", label: "Small" },
+				{ value: "medium", label: "Medium" },
+				{ value: "large", label: "Large" },
+				{ value: "xlarge", label: "Extra large" },
+				{ value: "huge", label: "Unbelievably, comically, ridiculously large" },
+			],
+		}),
+		placeholder: "Select a size",
+		label: "Size",
+		portal: true,
+		alignItemWithTrigger: true,
+		defaultValue: ["medium"],
+	},
+	render: (args: Story["args"]) => (
+		<div class="flex min-h-screen items-center justify-center p-8">
+			<Select {...args} />
+		</div>
+	),
+};
+
+export const AlignItemWithTriggerLongList: Story = {
+	args: {
+		className: "min-w-[250px]",
+		collection,
+		placeholder: "Select a fruit",
+		label: "Fruits",
+		portal: true,
+		alignItemWithTrigger: true,
+		defaultValue: ["raspberry"],
+	},
+	render: (args: Story["args"]) => (
+		<div class="flex min-h-screen items-center justify-center p-8">
+			<Select {...args} />
+		</div>
+	),
+};
+
 export const Invalid: Story = {
 	...Default,
 	args: {

--- a/packages/solid/src/components/select/Select.test.tsx
+++ b/packages/solid/src/components/select/Select.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { createListCollection, Select, type SelectItem } from ".";
 
@@ -40,5 +41,114 @@ describe("Select", () => {
 		));
 		expect(screen.getByTestId("sel2--trigger")).toHaveClass("slot-trigger");
 		expect(screen.getByTestId("sel2--value-text")).toHaveClass("slot-value");
+	});
+
+	it("sets data-align-item-with-trigger when alignItemWithTrigger is enabled", () => {
+		render(() => (
+			<Select
+				testId="sel3"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+			/>
+		));
+		expect(screen.getByTestId("sel3--root")).toHaveAttribute("data-align-item-with-trigger");
+	});
+
+	it("reopens after closing when alignItemWithTrigger is enabled", async () => {
+		const user = userEvent.setup();
+		render(() => (
+			<Select
+				testId="sel4"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+				defaultValue={["a"]}
+			/>
+		));
+
+		await user.click(screen.getByTestId("sel4--trigger"));
+		expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "true");
+		expect(await screen.findByTestId("sel4--content")).toBeVisible();
+
+		await user.click(screen.getByTestId("sel4--trigger"));
+		await waitFor(() => {
+			expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "false");
+		});
+
+		await user.click(screen.getByTestId("sel4--trigger"));
+		await waitFor(() => {
+			expect(screen.getByTestId("sel4--trigger")).toHaveAttribute("aria-expanded", "true");
+		});
+		expect(await screen.findByTestId("sel4--content")).toBeVisible();
+	});
+
+	it("shows dropdown when alignItemWithTrigger is enabled with no selection", async () => {
+		const user = userEvent.setup();
+		render(() => (
+			<Select
+				testId="sel5"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+			/>
+		));
+
+		await user.click(screen.getByTestId("sel5--trigger"));
+
+		expect(await screen.findByTestId("sel5--content")).toBeVisible();
+		await waitFor(() => {
+			expect(screen.getByTestId("sel5--positioner")).not.toHaveAttribute(
+				"data-align-item-with-trigger-pending",
+			);
+		});
+	});
+
+	it("skips alignment when opened via touch", async () => {
+		render(() => (
+			<Select
+				testId="sel6"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				alignItemWithTrigger
+				defaultValue={["a"]}
+			/>
+		));
+
+		const trigger = screen.getByTestId("sel6--trigger");
+		fireEvent.pointerDown(trigger, { pointerType: "touch" });
+		fireEvent.click(trigger);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("sel6--content")).toHaveAttribute("data-state", "open");
+		});
+		expect(screen.getByTestId("sel6--positioner")).not.toHaveAttribute(
+			"data-align-item-with-trigger",
+		);
+	});
+
+	it("preserves custom ids when alignItemWithTrigger is disabled", async () => {
+		render(() => (
+			<Select
+				testId="sel7"
+				label="Pick"
+				collection={collection}
+				placeholder="Choose"
+				portal={false}
+				ids={{ trigger: "custom-trigger", content: "custom-content" }}
+			/>
+		));
+
+		expect(screen.getByTestId("sel7--trigger")).toHaveAttribute("id", "custom-trigger");
+		await userEvent.setup().click(screen.getByTestId("sel7--trigger"));
+		expect(await screen.findByTestId("sel7--content")).toHaveAttribute("id", "custom-content");
 	});
 });

--- a/packages/solid/src/components/select/Select.tsx
+++ b/packages/solid/src/components/select/Select.tsx
@@ -1,9 +1,19 @@
 import { Select as ArkSelect, useSelect } from "@ark-ui/solid/select";
 import type { SelectProps as CoreSelectProps } from "@temporal-ui/core/select";
+import { alignItemWithTriggerPositioning } from "@temporal-ui/core/select";
 import { cx } from "@temporal-ui/core/utils/cx";
 import { testId } from "@temporal-ui/core/utils/string";
 import { ChevronsUpDown, X } from "lucide-solid";
-import { mergeProps, Show, splitProps, type JSX } from "solid-js";
+import {
+	createEffect,
+	createMemo,
+	createSignal,
+	createUniqueId,
+	mergeProps,
+	Show,
+	splitProps,
+	type JSX,
+} from "solid-js";
 import { Portal } from "solid-js/web";
 import { Field, fieldAttributes } from "../field";
 import { SelectContent, type SelectItem } from "./SelectContent";
@@ -20,18 +30,69 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 		"class",
 		"deselectable",
 		"placeholder",
+		"alignItemWithTrigger",
+		"alignItemWithTriggerMinHeight",
 	]);
+
+	const [openedWithTouch, setOpenedWithTouch] = createSignal(false);
+	const selectInstanceId = createUniqueId();
+	const selectIds = createMemo(() => {
+		if (!controlProps.alignItemWithTrigger) {
+			return undefined;
+		}
+		const id = selectInstanceId;
+		return {
+			control: `${id}-control`,
+			trigger: `${id}-trigger`,
+			valueText: `${id}-value-text`,
+			positioner: `${id}-positioner`,
+			content: `${id}-content`,
+		};
+	});
 
 	const useSelectProps = mergeProps(rootProps, {
 		disabled: fieldProps.disabled,
 		invalid: !!fieldProps.error,
 		required: fieldProps.required,
 		readOnly: fieldProps.readOnly,
+		ids:
+			controlProps.alignItemWithTrigger && selectIds()
+				? {
+						...rootProps.ids,
+						control: selectIds()!.control,
+						trigger: selectIds()!.trigger,
+						positioner: selectIds()!.positioner,
+						content: selectIds()!.content,
+					}
+				: rootProps.ids,
+		positioning: controlProps.alignItemWithTrigger
+			? {
+					...alignItemWithTriggerPositioning,
+					...rootProps.positioning,
+					getAnchorElement: () => document.getElementById(selectIds()!.control),
+				}
+			: rootProps.positioning,
 	});
 
 	const select = useSelect(useSelectProps);
 
 	const tid = testId(fieldProps.testId);
+
+	createEffect(() => {
+		if (!select().open) {
+			setOpenedWithTouch(false);
+		}
+	});
+
+	const contentProps = () => ({
+		tid,
+		maxHeight: controlProps.maxDropdownHeight,
+		classes: fieldProps.classes,
+		alignItemWithTrigger: controlProps.alignItemWithTrigger,
+		alignItemWithTriggerMinHeight: controlProps.alignItemWithTriggerMinHeight,
+		openedWithTouch: openedWithTouch(),
+		selectIds: selectIds(),
+	});
 
 	return (
 		<Field {...fieldProps} testId={tid("-field")}>
@@ -39,15 +100,29 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 				value={select}
 				class={fieldProps.classes?.selectRoot}
 				data-testid={tid("--root")}
+				data-align-item-with-trigger={controlProps.alignItemWithTrigger ? "" : undefined}
 			>
 				<ArkSelect.Control
+					id={selectIds()?.control}
 					aria-invalid={!!fieldProps.error}
-					class={cx(fieldProps.classes?.control, controlProps.class)}
+					class={cx(fieldProps.classes?.control, controlProps.class, controlProps.className)}
 					data-testid={tid("--control")}
 				>
-					<ArkSelect.Trigger class={fieldProps.classes?.trigger} data-testid={tid("--trigger")}>
+					<ArkSelect.Trigger
+						id={selectIds()?.trigger}
+						class={fieldProps.classes?.trigger}
+						data-testid={tid("--trigger")}
+						onPointerDown={
+							controlProps.alignItemWithTrigger
+								? (event) => {
+										setOpenedWithTouch(event.pointerType === "touch");
+									}
+								: undefined
+						}
+					>
 						{select().selectedItems[0]?.icon || controlProps.icon}
 						<ArkSelect.ValueText
+							id={selectIds()?.valueText}
 							class={fieldProps.classes?.valueText}
 							placeholder={controlProps.placeholder}
 							data-testid={tid("--value-text")}
@@ -64,19 +139,11 @@ export function Select<D = unknown>(_props: SelectProps<D>) {
 				</ArkSelect.Control>
 				<Show when={controlProps.portal}>
 					<Portal>
-						<SelectContent
-							tid={tid}
-							maxHeight={controlProps.maxDropdownHeight}
-							classes={fieldProps.classes}
-						/>
+						<SelectContent {...contentProps()} />
 					</Portal>
 				</Show>
 				<Show when={!controlProps.portal}>
-					<SelectContent
-						tid={tid}
-						maxHeight={controlProps.maxDropdownHeight}
-						classes={fieldProps.classes}
-					/>
+					<SelectContent {...contentProps()} />
 				</Show>
 				<ArkSelect.HiddenSelect data-testid={tid("--input")} />
 			</ArkSelect.RootProvider>

--- a/packages/solid/src/components/select/SelectContent.tsx
+++ b/packages/solid/src/components/select/SelectContent.tsx
@@ -2,12 +2,23 @@ import { Select as ArkSelect, useSelectContext } from "@ark-ui/solid/select";
 import type { SelectItem as CoreSelectItem } from "@temporal-ui/core/select";
 import { CheckIcon } from "lucide-solid";
 import { For, mergeProps, Show, type JSX } from "solid-js";
+import { useAlignItemWithTrigger } from "./use-align-item-with-trigger";
 
 export type SelectItem<D = unknown> = CoreSelectItem<D, JSX.Element>;
 
 export interface SelectContentProps {
 	tid: (str: string) => string | undefined;
 	maxHeight?: number;
+	alignItemWithTrigger?: boolean;
+	alignItemWithTriggerMinHeight?: number;
+	openedWithTouch?: boolean;
+	selectIds?: {
+		control: string;
+		trigger: string;
+		valueText: string;
+		positioner: string;
+		content: string;
+	};
 	classes?: {
 		content?: string;
 		itemGroup?: string;
@@ -24,57 +35,81 @@ export interface SelectContentProps {
 export function SelectContent(_props: SelectContentProps) {
 	const props = mergeProps({ maxHeight: 500 }, _props);
 	const context = useSelectContext();
+	const { alignedStyles, isAlignPending, showAligned, shouldAlign } = useAlignItemWithTrigger(
+		context,
+		() => ({
+			alignItemWithTrigger: props.alignItemWithTrigger,
+			alignItemWithTriggerMinHeight: props.alignItemWithTriggerMinHeight,
+			openedWithTouch: props.openedWithTouch,
+			selectIds: props.selectIds,
+		}),
+	);
 
 	return (
-		<ArkSelect.Positioner class={props.classes?.positioner} data-testid={props.tid("--positioner")}>
-			<ArkSelect.Content
-				class={props.classes?.content}
-				data-testid={props.tid("--content")}
-				style={{ "max-height": `${props.maxHeight}px` }}
+		<ArkSelect.Positioner
+			id={props.selectIds?.positioner}
+			class={props.classes?.positioner}
+			data-testid={props.tid("--positioner")}
+			data-align-item-with-trigger={shouldAlign() ? "" : undefined}
+			data-align-item-with-trigger-pending={isAlignPending() ? "" : undefined}
+			style={showAligned() ? alignedStyles()?.positioner : undefined}
+		>
+			<div
+				data-align-item-with-trigger-active={showAligned() ? "" : undefined}
+				style={showAligned() ? alignedStyles()?.popup : { display: "contents" }}
 			>
-				<div data-component="select" data-slot="list" data-testid={props.tid("--content-list")}>
-					<For each={context().collection.group()}>
-						{([type, group]) => (
-							<ArkSelect.ItemGroup
-								class={props.classes?.itemGroup}
-								data-testid={props.tid("--item-group")}
-							>
-								<Show when={type}>
-									<ArkSelect.ItemGroupLabel
-										class={props.classes?.itemGroupLabel}
-										data-testid={props.tid("--item-group-label")}
-									>
-										{type}
-									</ArkSelect.ItemGroupLabel>
-								</Show>
-								<For each={group}>
-									{(item) => (
-										<ArkSelect.Item
-											class={props.classes?.item}
-											data-testid={props.tid("--item")}
-											item={item}
+				<ArkSelect.Content
+					id={props.selectIds?.content}
+					class={props.classes?.content}
+					data-testid={props.tid("--content")}
+					style={
+						showAligned() ? alignedStyles()?.content : { "max-height": `${props.maxHeight}px` }
+					}
+				>
+					<div data-component="select" data-slot="list" data-testid={props.tid("--content-list")}>
+						<For each={context().collection.group()}>
+							{([type, group]) => (
+								<ArkSelect.ItemGroup
+									class={props.classes?.itemGroup}
+									data-testid={props.tid("--item-group")}
+								>
+									<Show when={type}>
+										<ArkSelect.ItemGroupLabel
+											class={props.classes?.itemGroupLabel}
+											data-testid={props.tid("--item-group-label")}
 										>
-											<Show when={item.icon}>{item.icon}</Show>
-											<ArkSelect.ItemText
-												class={props.classes?.itemText}
-												data-testid={props.tid("--item-text")}
+											{type}
+										</ArkSelect.ItemGroupLabel>
+									</Show>
+									<For each={group}>
+										{(item) => (
+											<ArkSelect.Item
+												class={props.classes?.item}
+												data-testid={props.tid("--item")}
+												item={item}
 											>
-												{item.label}
-											</ArkSelect.ItemText>
-											<ArkSelect.ItemIndicator
-												class={props.classes?.itemIndicator}
-												data-testid={props.tid("--item-indicator")}
-											>
-												<CheckIcon />
-											</ArkSelect.ItemIndicator>
-										</ArkSelect.Item>
-									)}
-								</For>
-							</ArkSelect.ItemGroup>
-						)}
-					</For>
-				</div>
-			</ArkSelect.Content>
+												<ArkSelect.ItemIndicator
+													class={props.classes?.itemIndicator}
+													data-testid={props.tid("--item-indicator")}
+												>
+													<CheckIcon />
+												</ArkSelect.ItemIndicator>
+												<Show when={item.icon}>{item.icon}</Show>
+												<ArkSelect.ItemText
+													class={props.classes?.itemText}
+													data-testid={props.tid("--item-text")}
+												>
+													{item.label}
+												</ArkSelect.ItemText>
+											</ArkSelect.Item>
+										)}
+									</For>
+								</ArkSelect.ItemGroup>
+							)}
+						</For>
+					</div>
+				</ArkSelect.Content>
+			</div>
 		</ArkSelect.Positioner>
 	);
 }

--- a/packages/solid/src/components/select/use-align-item-with-trigger.ts
+++ b/packages/solid/src/components/select/use-align-item-with-trigger.ts
@@ -1,0 +1,177 @@
+import type { useSelectContext } from "@ark-ui/solid/select";
+import {
+	ALIGN_ITEM_WITH_TRIGGER_MAX_RETRIES,
+	alignItemWithTriggerFallbackPositioning,
+	areAlignItemWithTriggerStylesEqual,
+	computeAlignItemWithTrigger,
+	querySelectedItemEl,
+	type AlignItemWithTriggerStyles,
+} from "@temporal-ui/core/select";
+import { createEffect, createMemo, createSignal, onCleanup, untrack } from "solid-js";
+import type { SelectContentProps } from "./SelectContent";
+
+function runAfterLayout(callback: () => void) {
+	requestAnimationFrame(() => {
+		requestAnimationFrame(callback);
+	});
+}
+
+/** Solid's `style` binding drops camelCase keys; convert to kebab-case. */
+function toKebabStyles(styles: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(styles).map(([key, value]) => [
+			key.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`),
+			value,
+		]),
+	);
+}
+
+function toSolidStyles(styles: AlignItemWithTriggerStyles): AlignItemWithTriggerStyles {
+	return {
+		positioner: toKebabStyles(styles.positioner),
+		popup: toKebabStyles(styles.popup),
+		content: toKebabStyles(styles.content),
+		scrollTop: styles.scrollTop,
+	};
+}
+
+export function useAlignItemWithTrigger(
+	context: ReturnType<typeof useSelectContext>,
+	props: () => Pick<
+		SelectContentProps,
+		"alignItemWithTrigger" | "alignItemWithTriggerMinHeight" | "openedWithTouch" | "selectIds"
+	>,
+) {
+	const [alignedStyles, setAlignedStyles] = createSignal<AlignItemWithTriggerStyles | undefined>();
+	const [alignEpoch, setAlignEpoch] = createSignal(0);
+	const [readyEpoch, setReadyEpoch] = createSignal(0);
+	const isOpen = createMemo(() => context().open);
+	let sessionCounter = 0;
+
+	const shouldAlign = createMemo(() => {
+		const currentProps = props();
+		return (
+			!!currentProps.alignItemWithTrigger &&
+			!currentProps.openedWithTouch &&
+			!untrack(() => context().multiple) &&
+			!!currentProps.selectIds
+		);
+	});
+
+	const isAlignPending = createMemo(
+		() => shouldAlign() && isOpen() && readyEpoch() !== alignEpoch(),
+	);
+
+	const showAligned = createMemo(() => !!alignedStyles() && isOpen() && !isAlignPending());
+
+	createEffect(() => {
+		if (!isOpen()) {
+			return;
+		}
+
+		const currentProps = untrack(props);
+		if (
+			!currentProps.alignItemWithTrigger ||
+			currentProps.openedWithTouch ||
+			untrack(() => context().multiple) ||
+			!currentProps.selectIds
+		) {
+			return;
+		}
+
+		const session = ++sessionCounter;
+		setAlignEpoch(session);
+		setAlignedStyles(undefined);
+
+		let cancelled = false;
+		let retries = 0;
+
+		const fallbackToStandardPlacement = () => {
+			setAlignedStyles(undefined);
+			setReadyEpoch(session);
+			untrack(() => context()).reposition(alignItemWithTriggerFallbackPositioning);
+		};
+
+		const alignOnce = () => {
+			if (cancelled || sessionCounter !== session) {
+				return;
+			}
+
+			const ids = currentProps.selectIds;
+			if (!ids) {
+				fallbackToStandardPlacement();
+				return;
+			}
+
+			const controlEl = document.getElementById(ids.control);
+			const triggerEl = document.getElementById(ids.trigger);
+			const valueTextEl = document.getElementById(ids.valueText);
+			const positionerEl = document.getElementById(ids.positioner);
+			const contentEl = document.getElementById(ids.content);
+
+			if (!controlEl || !triggerEl || !valueTextEl || !positionerEl || !contentEl) {
+				if (++retries >= ALIGN_ITEM_WITH_TRIGGER_MAX_RETRIES) {
+					fallbackToStandardPlacement();
+					return;
+				}
+				runAfterLayout(alignOnce);
+				return;
+			}
+
+			const selectedItemEl = querySelectedItemEl(contentEl);
+			if (!selectedItemEl) {
+				fallbackToStandardPlacement();
+				return;
+			}
+
+			const result = computeAlignItemWithTrigger({
+				controlEl,
+				triggerEl,
+				valueTextEl,
+				contentEl,
+				positionerEl,
+				selectedItemEl,
+				minHeight: currentProps.alignItemWithTriggerMinHeight,
+			});
+
+			if (cancelled || sessionCounter !== session) {
+				return;
+			}
+
+			if (result.status === "fallback") {
+				fallbackToStandardPlacement();
+				return;
+			}
+
+			const styles = toSolidStyles(result.styles);
+			setAlignedStyles((current) =>
+				areAlignItemWithTriggerStylesEqual(current, styles) ? current : styles,
+			);
+			setReadyEpoch(session);
+		};
+
+		queueMicrotask(() => {
+			runAfterLayout(alignOnce);
+		});
+
+		onCleanup(() => {
+			cancelled = true;
+		});
+	});
+
+	// Scroll after the aligned styles are committed: the target offset is computed
+	// for the final popup height and would be clamped by the pending max-height.
+	createEffect(() => {
+		const styles = alignedStyles();
+		const ids = props().selectIds;
+		if (!styles || !isOpen() || !ids) {
+			return;
+		}
+		const contentEl = document.getElementById(ids.content);
+		if (contentEl) {
+			contentEl.scrollTop = styles.scrollTop;
+		}
+	});
+
+	return { alignedStyles, isAlignPending, showAligned, shouldAlign };
+}

--- a/packages/solid/vitest.setup.ts
+++ b/packages/solid/vitest.setup.ts
@@ -6,4 +6,9 @@ class ResizeObserverStub {
 }
 globalThis.ResizeObserver = ResizeObserverStub;
 
+/** jsdom does not implement Element.scrollTo; zag select scrolls the content element on open. */
+if (!Element.prototype.scrollTo) {
+	Element.prototype.scrollTo = () => {};
+}
+
 import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- Add opt-in `alignItemWithTrigger` prop to Select (React + Solid) for macOS-style dropdown alignment
- Shared core geometry utility with viewport clamping, scroll compensation, and fallback conditions
- Code review fixes: fallback when no selection, restore global animations, scope ID override to align mode
- Bump package versions to **0.10.2** (published to npm)

## Test plan
- [x] Core alignment unit tests pass
- [x] React/Solid Select integration tests pass (no-selection open, touch bypass, custom ids, reopen)
- [x] `bun run build` succeeds
- [x] Published `@temporal-ui/core@0.10.2`, `@temporal-ui/react@0.10.2`, `@temporal-ui/solid@0.10.2`

## Linear
https://linear.app/temprix/issue/TPX-916/select-alignitemwithtrigger-macos-style-dropdown-alignment

Made with [Cursor](https://cursor.com)