### PR TITLE
Simplify Dependabot auto-merge workflow (TPX-985)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,18 +17,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
-           steps.meta.outputs.dependency-type == 'direct:development')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- Remove explicit PR approval from the Dependabot auto-merge workflow
- Remove semver and dependency-type filters so all Dependabot PRs enable squash auto-merge once CI passes

Linear: https://linear.app/temprix/issue/TPX-985/simplify-dependabot-auto-merge-workflow

## Test plan
- [x] Workflow YAML is valid
- [ ] Verify next Dependabot PR gets auto-merge enabled after CI passes


Made with [Cursor](https://cursor.com)